### PR TITLE
CLI の基本構造を追加

### DIFF
--- a/src/commands/translate.ts
+++ b/src/commands/translate.ts
@@ -1,0 +1,64 @@
+import * as fs from 'fs';
+import { TranslateOptions } from '../types';
+
+export async function translate(text: string | undefined, options: TranslateOptions): Promise<void> {
+  try {
+    // 標準入力からの読み込み処理
+    if (!text && !options.file && !process.stdin.isTTY) {
+      const stdin = await readStdin();
+      await processTranslation(stdin, options);
+      return;
+    }
+
+    // ファイルからの読み込み処理
+    if (options.file) {
+      const fileContent = fs.readFileSync(options.file, 'utf-8');
+      await processTranslation(fileContent, options);
+      return;
+    }
+
+    // 引数で渡されたテキストの処理
+    if (text) {
+      await processTranslation(text, options);
+      return;
+    }
+
+    console.error('Error: 入力が提供されていません');
+    process.exit(1);
+  } catch (error) {
+    console.error('Error:', error instanceof Error ? error.message : error);
+    process.exit(1);
+  }
+}
+
+async function processTranslation(text: string, options: TranslateOptions): Promise<void> {
+  // TODO: 実際の翻訳処理を実装
+  const translated = `[翻訳結果] ${text}`;
+
+  // 出力処理
+  if (options.output) {
+    fs.writeFileSync(options.output, translated, 'utf-8');
+    console.log(`${options.output} に翻訳結果を保存しました`);
+  } else {
+    console.log(translated);
+  }
+}
+
+function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    process.stdin.setEncoding('utf-8');
+
+    process.stdin.on('data', (chunk) => {
+      data += chunk;
+    });
+
+    process.stdin.on('end', () => {
+      resolve(data);
+    });
+
+    process.stdin.on('error', (error) => {
+      reject(error);
+    });
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 
 import { readFileSync } from "fs";
 import { Command } from 'commander';
+import { translate } from "./commands/translate.js";
 
 const pkgJson = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf-8"));
 
@@ -12,9 +13,12 @@ program
   .usage('[arguments] [options]')
   .description(`Description: ${pkgJson.description}`)
   .version(pkgJson.version, '-v, --version', 'output the current version')
+  .argument('[text]', 'テキストを翻訳する')
+  .option('-f, --file <path>', 'ファイルを翻訳する')
+  .option('-o, --output <path>', 'ファイルに出力する (デフォルト: 標準出力)')
   .showHelpAfterError()
   .addHelpText('after',
-  `\nExamples:
+    `\nExamples:
   $ enja "Hello, world!"     # 引数で渡された文字列を翻訳
   $ git --help | enja        # パイプ(標準入力)で渡されたテキストを翻訳
   $ enja -f input.txt        # ファイルからテキストを読み込んで翻訳
@@ -23,6 +27,7 @@ program
   )
   .addHelpText('afterAll', `\nEnja CLI v${pkgJson.version}`)
   .addHelpText('afterAll', 'Copyright (c) 2025 yhotta240')
-  .addHelpText('afterAll', 'GitHub: https://github.com/yhotamos/enja-cli');
+  .addHelpText('afterAll', 'GitHub: https://github.com/yhotamos/enja-cli')
+  .action(translate);
 
 program.parse();

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,4 @@
+export interface TranslateOptions {
+  file?: string;
+  output?: string;
+}


### PR DESCRIPTION
- CLI の基本構造を実装し，3 つの入力方法（引数，標準入力，ファイル）と出力機能の骨格を作成する．
- 翻訳処理は実装せず，スタブで動作確認のみ行う．

Closes #1 