### PR TITLE
HTMLタグを除去するオプションを追加

### DIFF
--- a/src/commands/translate.ts
+++ b/src/commands/translate.ts
@@ -41,11 +41,20 @@ async function processTranslation(text: string, options: TranslateOptions): Prom
     throw new Error('Translation Error: 翻訳するテキストが空です');
   }
 
+  // HTMLタグ除去
+  let processedText = text;
+  if (options.stripHtml) {
+    processedText = stripHtmlTags(text);
+    if (!processedText || processedText.trim().length === 0) {
+      throw new Error('Translation Error: HTMLタグを除去した結果，翻訳するテキストが空になりました');
+    }
+  }
+
   // 翻訳サービスの初期化
   const translator = createTranslator();
 
   // 翻訳処理
-  const result = await translator.translate(text, 'en', 'ja');
+  const result = await translator.translate(processedText, 'en', 'ja');
   const translated = result.text;
 
   // 出力処理
@@ -78,4 +87,19 @@ function readStdin(): Promise<string> {
       reject(error);
     });
   });
+}
+
+function stripHtmlTags(html: string): string {
+  return html
+    .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
+    .replace(/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi, '')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\n\s*\n/g, '\n')
+    .trim();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ program
   .argument('[text]', 'テキストを翻訳する')
   .option('-f, --file <path>', 'ファイルを翻訳する')
   .option('-o, --output <path>', 'ファイルに出力する (デフォルト: 標準出力)')
+  .option('-s, --strip-html', 'HTMLタグを除去してから翻訳する')
   .showHelpAfterError()
   .addHelpText('after',
     `\nExamples:
@@ -23,7 +24,8 @@ program
   $ git --help | enja        # パイプ(標準入力)で渡されたテキストを翻訳
   $ enja -f input.txt        # ファイルからテキストを読み込んで翻訳
   $ enja -f input.txt -o output.txt  # ファイルから読み込み，翻訳結果をファイルに保存
-  $ cat README.md | enja -o japanese.md  # パイプとファイル出力の組み合わせ`
+  $ cat README.md | enja -o japanese.md  # パイプとファイル出力の組み合わせ
+  $ curl -s https://example.com | enja -s  # HTMLタグを除去して翻訳`
   )
   .addHelpText('afterAll', `\nEnja CLI v${pkgJson.version}`)
   .addHelpText('afterAll', 'Copyright (c) 2025 yhotta240')

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 export interface TranslateOptions {
   file?: string;
   output?: string;
+  stripHtml?: boolean;
 }


### PR DESCRIPTION
追加した機能:

- -s, --strip-html オプション: HTMLタグを除去してから翻訳
- <script>, <style> タグとその中身を完全削除
- HTMLエンティティ（&nbsp;, < など）をデコード
- 余分な改行を削除

使用例:

`curl -s https://example.com | enja -s`

Closes #5