### PR TITLE
feat: 翻訳履歴の保存・参照機能を追加

### DIFF
--- a/src/commands/history.ts
+++ b/src/commands/history.ts
@@ -1,0 +1,28 @@
+import { HistoryOptions } from '../types/index.js';
+import { HistoryStorage } from '../services/history/storage.js';
+import { formatHistory } from '../services/history/formatter.js';
+
+/** 履歴コマンドの実行 */
+export async function history(options: HistoryOptions): Promise<void> {
+  try {
+    const storage = new HistoryStorage();
+
+    // 履歴クリア
+    if (options.clear) {
+      await storage.clear();
+      console.log('✓ 履歴をクリアしました');
+      return;
+    }
+
+    // 履歴表示
+    const limit = options.n || 10;
+    const entries = await storage.getRecent(limit);
+
+    const output = formatHistory(entries, options.detail);
+    console.log(output);
+
+  } catch (error) {
+    console.error('Error:', error instanceof Error ? error.message : error);
+    process.exit(1);
+  }
+}

--- a/src/commands/translate.ts
+++ b/src/commands/translate.ts
@@ -2,13 +2,15 @@ import * as fs from 'fs';
 import ora from 'ora';
 import { TranslateOptions } from '../types/index.js';
 import { createTranslator } from '../services/translator/factory.js';
+import { HistoryStorage } from '../services/history/storage.js';
+import { hashText } from '../utils/hash.js';
 
 export async function translate(text: string | undefined, options: TranslateOptions): Promise<void> {
   try {
     // 標準入力からの読み込み処理
     if (!text && !options.file && !process.stdin.isTTY) {
       const stdin = await readStdin();
-      await processTranslation(stdin, options);
+      await processTranslation(stdin, options, 'stdin');
       return;
     }
 
@@ -18,13 +20,13 @@ export async function translate(text: string | undefined, options: TranslateOpti
         throw new Error(`File Not Found Error: ${options.file} が見つかりません`);
       }
       const fileContent = fs.readFileSync(options.file, 'utf-8');
-      await processTranslation(fileContent, options);
+      await processTranslation(fileContent, options, 'file');
       return;
     }
 
     // 引数で渡されたテキストの処理
     if (text) {
-      await processTranslation(text, options);
+      await processTranslation(text, options, 'arg');
       return;
     }
 
@@ -37,7 +39,7 @@ export async function translate(text: string | undefined, options: TranslateOpti
   }
 }
 
-async function processTranslation(text: string, options: TranslateOptions): Promise<void> {
+async function processTranslation(text: string, options: TranslateOptions, inputMethod: 'arg' | 'stdin' | 'file'): Promise<void> {
   if (!text || text.trim().length === 0) {
     throw new Error('Translation Error: 翻訳するテキストが空です');
   }
@@ -53,10 +55,33 @@ async function processTranslation(text: string, options: TranslateOptions): Prom
 
   // 翻訳サービスの初期化
   const translator = createTranslator();
+  const historyStorage = new HistoryStorage();
 
   // 翻訳処理
   const sourceLang = options.flip ? 'ja' : 'en';
   const targetLang = options.flip ? 'en' : 'ja';
+
+  // キャッシュチェック
+  const textHash = hashText(processedText);
+  const cachedEntry = await historyStorage.findByHash(textHash, sourceLang, targetLang);
+
+  if (cachedEntry) {
+    console.log('✓ キャッシュから翻訳結果を取得しました');
+    const translated = cachedEntry.translatedText;
+
+    // 出力処理
+    if (options.output) {
+      try {
+        fs.writeFileSync(options.output, translated, 'utf-8');
+        console.log(`✓ ${options.output} に翻訳結果を保存しました`);
+      } catch (error) {
+        throw new Error(`File Write Error: ${options.output} への書き込みに失敗しました - ${error instanceof Error ? error.message : error}`);
+      }
+    } else {
+      console.log(translated);
+    }
+    return;
+  }
 
   const dir = `(${sourceLang} → ${targetLang})`;
   const spinner = ora(`翻訳中... ${dir}`).start();
@@ -64,6 +89,22 @@ async function processTranslation(text: string, options: TranslateOptions): Prom
     const result = await translator.translate(processedText, sourceLang, targetLang);
     const translated = result.text;
     spinner.succeed(`翻訳完了 ${dir}`);
+
+    // 履歴に保存
+    await historyStorage.add({
+      sourceText: processedText,
+      translatedText: translated,
+      sourceLang,
+      targetLang,
+      textLength: processedText.length,
+      sourceHash: textHash,
+      options: {
+        stripHtml: options.stripHtml,
+        file: options.file,
+        inputMethod,
+      },
+    });
+
     // 出力処理
     if (options.output) {
       try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
 import { readFileSync } from "fs";
 import { Command } from 'commander';
 import { translate } from "./commands/translate.js";
+import { history } from "./commands/history.js";
 
 const pkgJson = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf-8"));
 
@@ -12,7 +13,10 @@ program
   .name('enja')
   .usage('[arguments] [options]')
   .description(`Description: ${pkgJson.description}`)
-  .version(pkgJson.version, '-v, --version', 'output the current version')
+  .version(pkgJson.version, '-v, --version', 'output the current version');
+
+// 翻訳コマンド (デフォルト)
+program
   .argument('[text]', 'テキストを翻訳する')
   .option('-f, --file <path>', 'ファイルを翻訳する')
   .option('-o, --output <path>', 'ファイルに出力する (デフォルト: 標準出力)')
@@ -32,5 +36,14 @@ program
   .addHelpText('afterAll', 'Copyright (c) 2025 yhotta240')
   .addHelpText('afterAll', 'GitHub: https://github.com/yhotamos/enja-cli')
   .action(translate);
+
+// 履歴コマンド
+program
+  .command('history')
+  .description('翻訳履歴を表示する')
+  .option('-d, --detail', '詳細表示')
+  .option('-n <number>', '表示件数 (デフォルト: 10)', '10')
+  .option('--clear', '履歴をクリア')
+  .action(history);
 
 program.parse();

--- a/src/services/history/formatter.ts
+++ b/src/services/history/formatter.ts
@@ -1,0 +1,74 @@
+import { HistoryEntry } from '../../types/index.js';
+
+/** 履歴エントリをフォーマットして文字列として返す */
+export function formatHistory(entries: HistoryEntry[], detailed: boolean = false): string {
+  if (entries.length === 0) {
+    return '履歴はありません';
+  }
+
+  if (!detailed) {
+    return formatSimple(entries);
+  }
+
+  return formatDetailed(entries);
+}
+
+/** 簡易フォーマット */
+function formatSimple(entries: HistoryEntry[]): string {
+  const lines: string[] = [];
+
+  lines.push(`全 ${entries.length} 件の履歴\n`);
+
+  entries.forEach((entry, index) => {
+    const date = new Date(entry.timestamp).toLocaleString('ja-JP');
+    const preview = entry.sourceText.length > 30
+      ? entry.sourceText.substring(0, 30) + '...'
+      : entry.sourceText;
+
+    lines.push(`[${index + 1}] ${entry.id.substring(0, 8)} | ${date}`);
+    lines.push(`    ${entry.sourceLang} → ${entry.targetLang} | ${preview}`);
+    lines.push('');
+  });
+
+  return lines.join('\n');
+}
+
+/** 詳細フォーマット */
+function formatDetailed(entries: HistoryEntry[]): string {
+  const lines: string[] = [];
+
+  lines.push(`全 ${entries.length} 件の履歴の詳細\n`);
+
+  entries.forEach((entry, index) => {
+    if (index > 0) {
+      lines.push('─'.repeat(60));
+    }
+
+    const date = new Date(entry.timestamp).toLocaleString('ja-JP');
+
+    lines.push(`ID: ${entry.id}`);
+    lines.push(`Date: ${date}`);
+    lines.push(`Direction: ${entry.sourceLang} → ${entry.targetLang}`);
+    lines.push(`Length: ${entry.textLength} characters`);
+
+    if (entry.options) {
+      const opts: string[] = [];
+      if (entry.options.inputMethod) opts.push(`input=${entry.options.inputMethod}`);
+      if (entry.options.stripHtml) opts.push('stripHtml=true');
+      if (entry.options.file) opts.push(`file=${entry.options.file}`);
+      if (opts.length > 0) {
+        lines.push(`Options: ${opts.join(', ')}`);
+      }
+    }
+
+    lines.push('');
+    lines.push(`Input:`);
+    lines.push(entry.sourceText);
+    lines.push('');
+    lines.push(`Output:`);
+    lines.push(entry.translatedText);
+    lines.push('');
+  });
+
+  return lines.join('\n');
+}

--- a/src/services/history/index.ts
+++ b/src/services/history/index.ts
@@ -1,0 +1,10 @@
+import { HistoryEntry } from '../../types/index.js';
+
+export interface HistoryManager {
+  add(entry: Omit<HistoryEntry, 'id' | 'timestamp'>): Promise<void>;
+  getAll(): Promise<HistoryEntry[]>;
+  getRecent(limit: number): Promise<HistoryEntry[]>;
+  clear(): Promise<void>;
+  findById(id: string): Promise<HistoryEntry | null>;
+  findByHash(hash: string, sourceLang: string, targetLang: string): Promise<HistoryEntry | null>;
+}

--- a/src/services/history/storage.ts
+++ b/src/services/history/storage.ts
@@ -1,0 +1,100 @@
+import * as fs from 'fs';
+import { randomUUID } from 'crypto';
+import { HistoryEntry } from '../../types/index.js';
+import { HistoryManager } from './index.js';
+import { getHistoryFilePath, getConfigDir } from '../../utils/paths.js';
+
+const MAX_HISTORY_ENTRIES = 100;
+
+/** 履歴管理のためのストレージクラス */
+export class HistoryStorage implements HistoryManager {
+  private filePath: string;
+
+  constructor() {
+    this.filePath = getHistoryFilePath();
+  }
+
+  /** 設定ディレクトリが存在しない場合は作成 */
+  private ensureConfigDir(): void {
+    const configDir = getConfigDir();
+    if (!fs.existsSync(configDir)) {
+      fs.mkdirSync(configDir, { recursive: true });
+    }
+  }
+
+  /** 履歴ファイルを読み込む */
+  private async readHistory(): Promise<HistoryEntry[]> {
+    try {
+      if (!fs.existsSync(this.filePath)) {
+        return [];
+      }
+      const data = fs.readFileSync(this.filePath, 'utf-8');
+      return JSON.parse(data) as HistoryEntry[];
+    } catch (error) {
+      console.error('履歴ファイルの読み込みに失敗しました:', error);
+      return [];
+    }
+  }
+
+  /** 履歴ファイルに書き込む */
+  private async writeHistory(entries: HistoryEntry[]): Promise<void> {
+    try {
+      this.ensureConfigDir();
+      fs.writeFileSync(this.filePath, JSON.stringify(entries, null, 2), 'utf-8');
+    } catch (error) {
+      throw new Error(`履歴ファイルの書き込みに失敗しました: ${error instanceof Error ? error.message : error}`);
+    }
+  }
+
+  /** 履歴にエントリを追加 */
+  async add(entry: Omit<HistoryEntry, 'id' | 'timestamp'>): Promise<void> {
+    const entries = await this.readHistory();
+
+    const newEntry: HistoryEntry = {
+      ...entry,
+      id: randomUUID(),
+      timestamp: new Date().toISOString(),
+    };
+
+    entries.unshift(newEntry);
+
+    // 最大エントリ数を超えた場合は古いエントリを削除
+    if (entries.length > MAX_HISTORY_ENTRIES) {
+      entries.splice(MAX_HISTORY_ENTRIES);
+    }
+
+    await this.writeHistory(entries);
+  }
+
+  /** すべての履歴を取得 */
+  async getAll(): Promise<HistoryEntry[]> {
+    return await this.readHistory();
+  }
+
+  /** 最近の履歴を取得 */
+  async getRecent(limit: number): Promise<HistoryEntry[]> {
+    const entries = await this.readHistory();
+    return entries.slice(0, limit);
+  }
+
+  /** 履歴をクリア */
+  async clear(): Promise<void> {
+    await this.writeHistory([]);
+  }
+
+  /** IDで履歴を検索 */
+  async findById(id: string): Promise<HistoryEntry | null> {
+    const entries = await this.readHistory();
+    return entries.find(entry => entry.id === id) || null;
+  }
+
+  /** ハッシュと翻訳方向で履歴を検索 */
+  async findByHash(hash: string, sourceLang: string, targetLang: string): Promise<HistoryEntry | null> {
+    const entries = await this.readHistory();
+    return entries.find(entry =>
+      entry.sourceHash === hash &&
+      entry.sourceLang === sourceLang &&
+      entry.targetLang === targetLang
+    ) || null;
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,3 +4,27 @@ export interface TranslateOptions {
   stripHtml?: boolean;
   flip?: boolean;
 }
+
+export interface HistoryEntry {
+  id: string;
+  timestamp: string;
+  sourceText: string;
+  translatedText: string;
+  sourceLang: string;
+  targetLang: string;
+  textLength: number;
+  sourceHash?: string;
+  options?: {
+    stripHtml?: boolean;
+    file?: string;
+    inputMethod?: 'arg' | 'stdin' | 'file';
+    command?: string;
+  };
+}
+
+export interface HistoryOptions {
+  detail?: boolean;
+  n?: number;
+  clear?: boolean;
+  replay?: string;
+}

--- a/src/utils/hash.ts
+++ b/src/utils/hash.ts
@@ -1,0 +1,6 @@
+import { createHash } from 'crypto';
+
+/** テキストの SHA-256 ハッシュを計算して返す */
+export function hashText(text: string): string {
+  return createHash('sha256').update(text).digest('hex');
+}

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -1,0 +1,23 @@
+import * as path from 'path';
+import * as os from 'os';
+
+/** OS の設定ディレクトリのパスを取得 */
+export function getConfigDir(): string {
+  const platform = process.platform;
+
+  if (platform === 'win32') {
+    const appData = process.env.APPDATA;
+    if (!appData) {
+      throw new Error('APPDATA environment variable is not set');
+    }
+    return path.join(appData, 'enja-cli');
+  }
+
+  const homeDir = os.homedir();
+  return path.join(homeDir, '.config', 'enja-cli');
+}
+
+/** 履歴ファイルのパスを取得 */
+export function getHistoryFilePath(): string {
+  return path.join(getConfigDir(), 'history.json');
+}


### PR DESCRIPTION
Closes #10

機能

- 翻訳履歴を自動保存（最大 100 件、`%APPDATA%\enja-cli\history.json`）
- `enja history` コマンドで履歴を表示・管理
- キャッシュ機能：同じテキストを再翻訳時は API を叩かずに履歴から取得

使い方

```bash
# 履歴表示（最新 10 件）
enja history

# 詳細表示
enja history -d

# 件数指定
enja history -n 20

# 履歴クリア
enja history --clear
```

変更内容

新規ファイル:

- `src/commands/history.ts` - 履歴コマンド
- `src/services/history/` - 履歴管理サービス
- `src/utils/paths.ts`, `src/utils/hash.ts` - ユーティリティ

変更ファイル:

- `src/commands/translate.ts` - 履歴保存とキャッシュチェック機能を追加
- `src/types/index.ts` - `HistoryEntry`, `HistoryOptions` 型を追加
- `src/index.ts` - `history` コマンドを登録