### PR TITLE
feat: キャッシュ無効化オプションを追加

### DIFF
--- a/src/commands/translate.ts
+++ b/src/commands/translate.ts
@@ -65,7 +65,7 @@ async function processTranslation(text: string, options: TranslateOptions, input
   const textHash = hashText(processedText);
   const cachedEntry = await historyStorage.findByHash(textHash, sourceLang, targetLang);
 
-  if (cachedEntry) {
+  if (cachedEntry && options.cache !== false) {
     console.log('✓ キャッシュから翻訳結果を取得しました');
     const translated = cachedEntry.translatedText;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ program
   .option('-f, --file <path>', 'ファイルを翻訳する')
   .option('-o, --output <path>', 'ファイルに出力する (デフォルト: 標準出力)')
   .option('-s, --strip-html', 'HTMLタグを除去してから翻訳する')
+  .option('-n, --no-cache', 'キャッシュを使用せずに再翻訳する')
   .option('-F, --flip', '翻訳方向を逆にする (デフォルト: 英語→日本語)')
   .option('--endpoint <url>', 'カスタム翻訳エンドポイントを指定')
   .option('--api-key <key>', 'API キーを指定')

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,7 @@ export interface TranslateOptions {
   file?: string;
   output?: string;
   stripHtml?: boolean;
+  cache?: boolean;
   flip?: boolean;
   endpoint?: string;
   apiKey?: string;


### PR DESCRIPTION
Closes #18

`--no-cache` オプションを追加
このオプションを使用すると，キャッシュを使用せずに再翻訳を実行できる．

使い方: 

```bash
# 翻訳する
enja "Hello World!"

# 二回目以降はデフォルトではキャッシュを使用して翻訳する
enja "Hello World!"

# キャッシュを無効化し，再翻訳する
enja "Hello World!" --no-cache
```