### PR TITLE
feat: コマンド出力に色を追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.2",
+        "kleur": "^4.1.5",
         "ora": "^9.0.0"
       },
       "bin": {
@@ -637,6 +638,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/log-symbols": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "type": "module",
   "dependencies": {
     "commander": "^14.0.2",
+    "kleur": "^4.1.5",
     "ora": "^9.0.0"
   },
   "devDependencies": {

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,5 +1,6 @@
 import { ConfigKey, ConfigOptions } from '../types/index.js';
 import { ConfigStorage } from '../services/config/storage.js';
+import kleur from 'kleur';
 
 /** 設定コマンドの実行 */
 export async function config(key?: ConfigKey, value?: string, options?: ConfigOptions): Promise<void> {
@@ -9,21 +10,21 @@ export async function config(key?: ConfigKey, value?: string, options?: ConfigOp
     // --reset: すべての設定をリセット
     if (options?.reset) {
       await storage.reset();
-      console.log('✓ 設定をリセットしました');
+      console.log(`${kleur.green('✔')} 設定をリセットしました`);
       return;
     }
 
     // --unset: 指定したキーを削除（デフォルトに戻す）
     if (options?.unset) {
       await storage.unset(options.unset);
-      console.log(`✓ ${options.unset} をリセットしました`);
+      console.log(`${kleur.green('✔')} ${options.unset} をリセットしました`);
       return;
     }
 
     // key と value が指定された場合: 設定を保存
     if (key && value) {
       await storage.set(key, value);
-      console.log(`✓ ${key} を設定しました`);
+      console.log(`${kleur.green('✔')} ${key} を設定しました`);
       return;
     }
 
@@ -46,9 +47,9 @@ export async function config(key?: ConfigKey, value?: string, options?: ConfigOp
 
     // --list または引数なし: すべての設定を表示
     const config = await storage.get();
-    console.log(`provider: ${config.provider}`);
-    console.log(`endpoint: ${config.endpoint}`);
-    console.log(`apiKey: ${config.apiKey ? maskApiKey(config.apiKey) : '(not set)'}`);
+    console.log(`${kleur.blue('provider:')} ${config.provider}`);
+    console.log(`${kleur.blue('endpoint:')} ${config.endpoint}`);
+    console.log(`${kleur.blue('apiKey:')} ${config.apiKey ? maskApiKey(config.apiKey) : '(not set)'}`);
 
   } catch (error) {
     if (error instanceof Error) {

--- a/src/commands/history.ts
+++ b/src/commands/history.ts
@@ -1,6 +1,7 @@
 import { HistoryOptions } from '../types/index.js';
 import { HistoryStorage } from '../services/history/storage.js';
 import { formatHistory } from '../services/history/formatter.js';
+import kleur from 'kleur';
 
 /** 履歴コマンドの実行 */
 export async function history(id: string, options: HistoryOptions): Promise<void> {
@@ -52,7 +53,7 @@ export async function history(id: string, options: HistoryOptions): Promise<void
       if (delId.length >= 36) {
         const deleted = await storage.deleteById(delId);
         if (deleted) {
-          console.log(`✓ 履歴ID ${delId} を削除しました`);
+          console.log(`${kleur.green('✔')} 履歴ID ${delId} を削除しました`);
         } else {
           throw new Error(`指定されたIDの履歴が見つかりません (${delId})`);
         }
@@ -81,7 +82,7 @@ export async function history(id: string, options: HistoryOptions): Promise<void
       const targetId = matches[0].id;
       const deleted = await storage.deleteById(targetId);
       if (deleted) {
-        console.log(`✓ 履歴ID ${targetId} を削除しました`);
+        console.log(`${kleur.green('✔')} 履歴ID ${targetId} を削除しました`);
       } else {
         throw new Error(`削除に失敗しました (${targetId})`);
       }
@@ -91,7 +92,7 @@ export async function history(id: string, options: HistoryOptions): Promise<void
     // 履歴クリア
     if (options.clear) {
       await storage.clear();
-      console.log('✓ 履歴をクリアしました');
+      console.log(`${kleur.green('✔')} 履歴をクリアしました`);
       return;
     }
 

--- a/src/commands/translate.ts
+++ b/src/commands/translate.ts
@@ -4,6 +4,7 @@ import { TranslateOptions } from '../types/index.js';
 import { createTranslator } from '../services/translator/factory.js';
 import { HistoryStorage } from '../services/history/storage.js';
 import { hashText } from '../utils/hash.js';
+import kleur from 'kleur';
 
 export async function translate(text: string | undefined, options: TranslateOptions): Promise<void> {
   try {
@@ -66,14 +67,14 @@ async function processTranslation(text: string, options: TranslateOptions, input
   const cachedEntry = await historyStorage.findByHash(textHash, sourceLang, targetLang);
 
   if (cachedEntry && options.cache !== false) {
-    console.log('✓ キャッシュから翻訳結果を取得しました');
+    console.log(`${kleur.green('✔')} キャッシュから翻訳結果を取得しました`);
     const translated = cachedEntry.translatedText;
 
     // 出力処理
     if (options.output) {
       try {
         fs.writeFileSync(options.output, translated, 'utf-8');
-        console.log(`✓ ${options.output} に翻訳結果を保存しました`);
+        console.log(`${kleur.green('✔')} ${options.output} に翻訳結果を保存しました`);
       } catch (error) {
         throw new Error(`error: ファイルへの書き込みに失敗しました (${options.output})`);
       }
@@ -109,7 +110,7 @@ async function processTranslation(text: string, options: TranslateOptions, input
     if (options.output) {
       try {
         fs.writeFileSync(options.output, translated, 'utf-8');
-        console.log(`✓ ${options.output} に翻訳結果を保存しました`);
+        console.log(`${kleur.green('✔')} ${options.output} に翻訳結果を保存しました`);
       } catch (error) {
         throw new Error(`error: ファイルへの書き込みに失敗しました (${options.output})`);
       }

--- a/src/services/history/formatter.ts
+++ b/src/services/history/formatter.ts
@@ -1,3 +1,4 @@
+import kleur from 'kleur';
 import { HistoryEntry } from '../../types/index.js';
 
 /** 履歴エントリをフォーマットして文字列として返す */
@@ -25,7 +26,7 @@ function formatSimple(entries: HistoryEntry[]): string {
       ? entry.sourceText.substring(0, 30) + '...'
       : entry.sourceText;
 
-    lines.push(`[${index + 1}] ${entry.id.substring(0, 8)} | ${date}`);
+    lines.push(`${kleur.cyan('[' + (index + 1) + ']')} ${entry.id.substring(0, 8)} | ${date}`);
     lines.push(`    ${entry.sourceLang} → ${entry.targetLang} | ${preview}`);
     lines.push('');
   });
@@ -46,10 +47,10 @@ function formatDetailed(entries: HistoryEntry[]): string {
 
     const date = new Date(entry.timestamp).toLocaleString('ja-JP');
 
-    lines.push(`ID: ${entry.id}`);
-    lines.push(`Date: ${date}`);
-    lines.push(`Direction: ${entry.sourceLang} → ${entry.targetLang}`);
-    lines.push(`Length: ${entry.textLength} characters`);
+    lines.push(`${kleur.cyan('ID:')} ${entry.id}`);
+    lines.push(`${kleur.cyan('Date:')} ${date}`);
+    lines.push(`${kleur.cyan('Direction:')} ${entry.sourceLang} → ${entry.targetLang}`);
+    lines.push(`${kleur.cyan('Length:')} ${entry.textLength} characters`);
 
     if (entry.options) {
       const opts: string[] = [];
@@ -57,15 +58,15 @@ function formatDetailed(entries: HistoryEntry[]): string {
       if (entry.options.stripHtml) opts.push('stripHtml=true');
       if (entry.options.file) opts.push(`file=${entry.options.file}`);
       if (opts.length > 0) {
-        lines.push(`Options: ${opts.join(', ')}`);
+        lines.push(`${kleur.cyan('Options:')} ${opts.join(', ')}`);
       }
     }
 
     lines.push('');
-    lines.push(`Input:`);
+    lines.push(`${kleur.cyan('Input:')}`);
     lines.push(entry.sourceText);
     lines.push('');
-    lines.push(`Output:`);
+    lines.push(`${kleur.cyan('Output:')}`);
     lines.push(entry.translatedText);
     lines.push('');
   });


### PR DESCRIPTION
'kleur' を使用し．主要コマンドと履歴フォーマッタの出力を色付きにした．

- 成功時のチェックマークを緑で表示
- `history` や `config` の表示でプロパティなどを色付け