### PR TITLE
fix: 改行を含む履歴エントリ表示を修正

### DIFF
--- a/src/services/history/formatter.ts
+++ b/src/services/history/formatter.ts
@@ -23,7 +23,7 @@ function formatSimple(entries: HistoryEntry[]): string {
   entries.forEach((entry, index) => {
     const date = new Date(entry.timestamp).toLocaleString('ja-JP');
     const preview = entry.sourceText.length > 30
-      ? entry.sourceText.substring(0, 30) + '...'
+      ? entry.sourceText.replace(/[\r\n]+/g, ' ').substring(0, 30) + '...'
       : entry.sourceText;
 
     lines.push(`${kleur.cyan('[' + (index + 1) + ']')} ${entry.id.substring(0, 8)} | ${date}`);


### PR DESCRIPTION
Closes #22

- `history` コマンドで改行を含む履歴エントリのプレビューが正しく表示されない問題を修正
- `src/services/history/formatter.ts` のエントリプレビュー生成部分を修正し，改行をスペースに置換するように変更．