### PR TITLE
feat: OpenAI 翻訳機能を追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "commander": "^14.0.2",
         "kleur": "^4.1.5",
+        "openai": "^6.9.1",
         "ora": "^9.0.0"
       },
       "bin": {
@@ -1268,6 +1269,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.9.1.tgz",
+      "integrity": "sha512-vQ5Rlt0ZgB3/BNmTa7bIijYFhz3YBceAA3Z4JuoMSBftBF9YqFHIEhZakSs+O/Ad7EaoEimZvHxD5ylRjN11Lg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/ora": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   "dependencies": {
     "commander": "^14.0.2",
     "kleur": "^4.1.5",
+    "openai": "^6.9.1",
     "ora": "^9.0.0"
   },
   "devDependencies": {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,32 +1,25 @@
-import { TranslateOptions } from '../types/index.js';
+import { ConfigProfile, TranslateOptions, TranslatorProvider } from '../types/index.js';
 import { ConfigStorage } from '../services/config/storage.js';
-
-export interface Config {
-  endpoint: string;
-  provider: 'gas' | 'custom';
-  apiKey?: string;
-}
 
 const DEFAULT_GAS_API_URL = "https://script.google.com/macros/s/AKfycbxOSbKD0aBTaQqIzHv00BMzp6WwrtWHBU3gJY0vhB2HblgUO-cgesfT1l-rrfttnWZzew/exec";
 
-export async function getConfig(options?: TranslateOptions): Promise<Config> {
+export async function getConfig(options?: TranslateOptions): Promise<ConfigProfile> {
   // 設定ファイルから読み込み
   const storage = new ConfigStorage();
   const fileConfig = await storage.get();
 
   // 優先順位: コマンドラインオプション > 設定ファイル > デフォルト値
-  const endpoint =
+  const endpoint: string =
     options?.endpoint ||
     fileConfig.endpoint ||
     DEFAULT_GAS_API_URL;
 
-  const apiKey =
+  const apiKey: string | undefined =
     options?.apiKey ||
-    fileConfig.apiKey ||
-    undefined;
+    fileConfig.apiKey;
 
-  const provider =
-    (options?.provider as 'gas' | 'custom') ||
+  const provider: TranslatorProvider =
+    options?.provider ||
     fileConfig.provider ||
     'gas';
 

--- a/src/services/config/storage.ts
+++ b/src/services/config/storage.ts
@@ -64,8 +64,8 @@ export class ConfigStorage implements ConfigManager {
         config.apiKey = value;
         break;
       case 'provider':
-        if (value !== 'gas' && value !== 'custom') {
-          throw new Error(`無効なプロバイダー (${value}): gas または custom を指定してください`);
+        if (value !== 'gas' && value !== 'custom' && value !== 'openai') {
+          throw new Error(`無効なプロバイダー (${value}): gas または custom または openai を指定してください`);
         }
         config.provider = value;
         break;

--- a/src/services/translator/factory.ts
+++ b/src/services/translator/factory.ts
@@ -1,15 +1,21 @@
 import { Translator } from './index.js';
 import { GASTranslator } from './gas.js';
-import { getConfig, Config } from '../../config/index.js';
-import { TranslateOptions } from '../../types/index.js';
+import { getConfig } from '../../config/index.js';
+import { ConfigProfile, TranslateOptions } from '../../types/index.js';
+import { OpenAITranslator } from './openai.js';
 
 export async function createTranslator(options?: TranslateOptions): Promise<Translator> {
-  const config: Config = await getConfig(options);
+  const config: ConfigProfile = await getConfig(options);
 
   switch (config.provider) {
     case 'gas':
     case 'custom':
       return new GASTranslator(config.endpoint, config.apiKey);
+    case 'openai':
+      if (!config.apiKey) {
+        throw new Error('OpenAIを使用するにはAPIキーが必要です');
+      }
+      return new OpenAITranslator(config.apiKey);
     default:
       throw new Error(`サポートされていないプロバイダー (${config.provider})`);
   }

--- a/src/services/translator/openai.ts
+++ b/src/services/translator/openai.ts
@@ -1,0 +1,61 @@
+import OpenAI from 'openai';
+import { Translator, TranslationResult } from './index.js';
+
+export class OpenAITranslator implements Translator {
+  private client: OpenAI;
+
+  constructor(apiKey: string) {
+    this.client = new OpenAI({
+      apiKey,
+    });
+  }
+
+  async translate(text: string, sourceLang: string, targetLang: string): Promise<TranslationResult> {
+    try {
+      const sourceLanguage = this.mapLanguageCode(sourceLang);
+      const targetLanguage = this.mapLanguageCode(targetLang);
+
+      const systemPrompt = `You are a professional translator. Translate the following text from ${sourceLanguage} to ${targetLanguage}. Only return the translated text without any additional explanation or comments.`;
+
+      const completion = await this.client.chat.completions.create({
+        model: 'gpt-4o-mini',
+        messages: [
+          {
+            role: 'system',
+            content: systemPrompt,
+          },
+          {
+            role: 'user',
+            content: text,
+          },
+        ],
+        temperature: 0.3,
+      });
+
+      const translatedText = completion.choices[0]?.message?.content;
+
+      if (!translatedText) {
+        throw new Error('翻訳に失敗しました');
+      }
+
+      return {
+        text: translatedText.trim(),
+        detectedSourceLang: sourceLang,
+      };
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new Error(`OpenAI翻訳エラー: ${error.message}`);
+      }
+      throw error;
+    }
+  }
+
+  private mapLanguageCode(code: string): string {
+    const languageMap: Record<string, string> = {
+      'en': 'English',
+      'ja': 'Japanese',
+    };
+
+    return languageMap[code.toLowerCase()] || code;
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,7 +6,7 @@ export interface TranslateOptions {
   flip?: boolean;
   endpoint?: string;
   apiKey?: string;
-  provider?: string;
+  provider?: TranslatorProvider;
 }
 
 export interface HistoryEntry {
@@ -36,7 +36,7 @@ export interface HistoryOptions {
 }
 
 export interface ConfigProfile {
-  provider: 'gas' | 'custom';
+  provider: TranslatorProvider;
   endpoint: string;
   apiKey?: string;
 }
@@ -48,3 +48,5 @@ export interface ConfigOptions {
 }
 
 export type ConfigKey = 'endpoint' | 'api-key' | 'provider';
+
+export type TranslatorProvider = 'gas' | 'custom' | 'openai';


### PR DESCRIPTION
Closes #32

OpenAI の GPT-4o-mini モデルを使った翻訳機能を追加

詳細:

- モデル: gpt-4o-mini を使用
- API: Chat Completions API（安定性と実績のある方式）
- Temperature: 0.3（翻訳の一貫性を重視）
- プロンプト: システムロールでプロの翻訳者として動作するよう指示

使い方:

```bash
# 設定として保存
enja config provider openai
enja config api-key YOUR_OPENAI_API_KEY

# 翻訳実行
enja "Hello, world!"

# または一時的に指定
enja "Hello, world!" --provider openai --api-key YOUR_KEY
```