### PR TITLE
feat: モデル設定の追加と翻訳プロバイダの更新

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -38,6 +38,8 @@ export async function config(key?: ConfigKey, value?: string, options?: ConfigOp
         console.log(config.apiKey ? maskApiKey(config.apiKey) : '(not set)');
       } else if (key === 'provider') {
         console.log(config.provider);
+      } else if (key === 'model') {
+        console.log(config.model || '(not set)');
       } else {
         throw new Error(`無効な設定キー (${key})`);
       }
@@ -49,6 +51,7 @@ export async function config(key?: ConfigKey, value?: string, options?: ConfigOp
     console.log(`${kleur.blue('provider:')} ${config.provider}`);
     console.log(`${kleur.blue('endpoint:')} ${config.endpoint}`);
     console.log(`${kleur.blue('apiKey:')} ${config.apiKey ? maskApiKey(config.apiKey) : '(not set)'}`);
+    console.log(`${kleur.blue('model:')} ${config.model || '(not set)'}`);
 
   } catch (error) {
     console.error(error instanceof Error ? `error: ${error.message}` : error);

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -23,9 +23,14 @@ export async function getConfig(options?: TranslateOptions): Promise<ConfigProfi
     fileConfig.provider ||
     'gas';
 
+  const model: string | undefined =
+    options?.model ||
+    fileConfig.model;
+
   return {
     endpoint,
     provider,
     apiKey,
+    model,
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ program
   .option('--endpoint <url>', 'カスタム翻訳エンドポイントを指定')
   .option('--api-key <key>', 'API キーを指定')
   .option('--provider <name>', '翻訳プロバイダーを指定 (gas, custom, openai, gemini)')
+  .option('--model <name>', '使用するモデル名を指定 (例: gpt-4o-mini, gemini-2.5-flash-lite)')
   .showHelpAfterError()
   .addHelpText('after',
     `\nExamples:
@@ -58,7 +59,7 @@ program
 program
   .command('config')
   .description('Description: 設定を管理する')
-  .argument('[key]', '設定キー (endpoint, api-key, provider)')
+  .argument('[key]', '設定キー (endpoint, api-key, provider, model)')
   .argument('[value]', '設定値')
   .option('-l, --list', '設定を一覧表示')
   .option('--unset <key>', '設定を削除（デフォルトに戻す）')

--- a/src/services/config/storage.ts
+++ b/src/services/config/storage.ts
@@ -7,6 +7,7 @@ const DEFAULT_CONFIG: ConfigProfile = {
   provider: 'gas',
   endpoint: 'https://script.google.com/macros/s/AKfycbxOSbKD0aBTaQqIzHv00BMzp6WwrtWHBU3gJY0vhB2HblgUO-cgesfT1l-rrfttnWZzew/exec',
   apiKey: undefined,
+  model: undefined,
 };
 
 /** 設定の永続化を管理するクラス */
@@ -70,6 +71,9 @@ export class ConfigStorage implements ConfigManager {
         }
         config.provider = value as TranslatorProvider;
         break;
+      case 'model':
+        config.model = value;
+        break;
       default:
         throw new Error(`無効な設定キー (${key})`);
     }
@@ -90,6 +94,9 @@ export class ConfigStorage implements ConfigManager {
         break;
       case 'provider':
         config.provider = DEFAULT_CONFIG.provider;
+        break;
+      case 'model':
+        config.model = DEFAULT_CONFIG.model;
         break;
       default:
         throw new Error(`無効な設定キー (${key})`);

--- a/src/services/translator/factory.ts
+++ b/src/services/translator/factory.ts
@@ -16,12 +16,12 @@ export async function createTranslator(options?: TranslateOptions): Promise<Tran
       if (!config.apiKey) {
         throw new Error('OpenAIを使用するにはAPIキーが必要です');
       }
-      return new OpenAITranslator(config.apiKey);
+      return new OpenAITranslator(config.apiKey, config.model || 'gpt-4o-mini');
     case 'gemini':
       if (!config.apiKey) {
         throw new Error('Geminiを使用するにはAPIキーが必要です');
       }
-      return new GeminiTranslator(config.apiKey);
+      return new GeminiTranslator(config.apiKey, config.model || 'gemini-2.5-flash-lite');
     default:
       throw new Error(`サポートされていないプロバイダー (${config.provider})`);
   }

--- a/src/services/translator/gemini.ts
+++ b/src/services/translator/gemini.ts
@@ -1,11 +1,13 @@
-import { GenerateContentResponse, GoogleGenAI } from "@google/genai";
+import { ApiError, GenerateContentResponse, GoogleGenAI, Model, Pager } from "@google/genai";
 import { Translator, TranslationResult } from './index.js';
 
 export class GeminiTranslator implements Translator {
   private client: GoogleGenAI;
+  private model: string;
 
-  constructor(apiKey: string) {
-    this.client = new GoogleGenAI({ apiKey });
+  constructor(apiKey: string, model: string) {
+    this.client = new GoogleGenAI({ apiKey: apiKey });
+    this.model = model;
   }
 
   async translate(text: string, sourceLang: string, targetLang: string): Promise<TranslationResult> {
@@ -16,7 +18,7 @@ export class GeminiTranslator implements Translator {
       const systemPrompt = `You are a professional translator. Translate the following text from ${sourceLanguage} to ${targetLanguage}. Only return the translated text without any additional explanation or comments.`;
 
       const response: GenerateContentResponse = await this.client.models.generateContent({
-        model: "gemini-2.5-flash-lite",
+        model: this.model,
         contents: text,
         config: {
           systemInstruction: systemPrompt,
@@ -34,7 +36,10 @@ export class GeminiTranslator implements Translator {
         detectedSourceLang: sourceLang,
       };
     } catch (error) {
-      if (error instanceof Error) {
+      if (error instanceof ApiError) {
+        const message = JSON.parse(error.message).error.message;
+        throw new Error(`Gemini翻訳APIエラー: ${message}`);
+      } else if (error instanceof Error) {
         throw new Error(`Gemini翻訳エラー: ${error.message}`);
       }
       throw error;

--- a/src/services/translator/openai.ts
+++ b/src/services/translator/openai.ts
@@ -3,11 +3,11 @@ import { Translator, TranslationResult } from './index.js';
 
 export class OpenAITranslator implements Translator {
   private client: OpenAI;
+  private model: string;
 
-  constructor(apiKey: string) {
-    this.client = new OpenAI({
-      apiKey,
-    });
+  constructor(apiKey: string, model: string) {
+    this.client = new OpenAI({ apiKey });
+    this.model = model;
   }
 
   async translate(text: string, sourceLang: string, targetLang: string): Promise<TranslationResult> {
@@ -18,7 +18,7 @@ export class OpenAITranslator implements Translator {
       const systemPrompt = `You are a professional translator. Translate the following text from ${sourceLanguage} to ${targetLanguage}. Only return the translated text without any additional explanation or comments.`;
 
       const completion = await this.client.chat.completions.create({
-        model: 'gpt-4o-mini',
+        model: this.model,
         messages: [
           {
             role: 'system',
@@ -43,7 +43,9 @@ export class OpenAITranslator implements Translator {
         detectedSourceLang: sourceLang,
       };
     } catch (error) {
-      if (error instanceof Error) {
+      if (error instanceof OpenAI.APIError) {
+        throw new Error(`OpenAI翻訳APIエラー: ${error.message}`);
+      } else if (error instanceof Error) {
         throw new Error(`OpenAI翻訳エラー: ${error.message}`);
       }
       throw error;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,6 +7,7 @@ export interface TranslateOptions {
   endpoint?: string;
   apiKey?: string;
   provider?: TranslatorProvider;
+  model?: string;
 }
 
 export interface HistoryEntry {
@@ -39,6 +40,7 @@ export interface ConfigProfile {
   provider: TranslatorProvider;
   endpoint: string;
   apiKey?: string;
+  model?: string;
 }
 
 export interface ConfigOptions {
@@ -47,6 +49,6 @@ export interface ConfigOptions {
   reset?: boolean;
 }
 
-export type ConfigKey = 'endpoint' | 'api-key' | 'provider';
+export type ConfigKey = 'endpoint' | 'api-key' | 'provider' | 'model';
 
 export type TranslatorProvider = 'gas' | 'custom' | 'openai' | 'gemini';


### PR DESCRIPTION
OpenAIとGemini翻訳プロバイダで使用するモデルを設定する機能を追加

変更内容:

機能追加
- `--model` オプションを追加（コマンドラインから指定可能）
- `enja config model <model-name>` で永続的な設定が可能
- デフォルトモデル: OpenAI=`gpt-4o-mini`, Gemini=`gemini-2.5-flash-lite`

改善点
- OpenAI/GeminiのAPIエラーハンドリングを改善
- ヘルプテキストにモデル設定の例を追加

コマンド
```bash
$ enja "Hello" --provider openai --model gpt-4o
```