### PR TITLE
fix: GASエンドポイント不具合を修正

### DIFF
--- a/src/services/config/storage.ts
+++ b/src/services/config/storage.ts
@@ -117,7 +117,8 @@ export class ConfigStorage implements ConfigManager {
   /** 指定したキーを削除（デフォルトに戻す） */
   async unset(key: string): Promise<void> {
     const config = await this.readConfig();
-    const defaultConfig = DEFAULT_PROFILES_BY_PROVIDER[config.provider] as ConfigProfile;
+    const provider = config.provider || 'gas';
+    const defaultConfig = DEFAULT_PROFILES_BY_PROVIDER[provider] as ConfigProfile;
     switch (key) {
       case 'endpoint':
         config.endpoint = defaultConfig.endpoint;
@@ -286,7 +287,8 @@ export class ConfigStorage implements ConfigManager {
     }
 
     const profile = appConfig.profiles[profileName];
-    const defaultProfile = DEFAULT_PROFILES_BY_PROVIDER[profile.provider] as ConfigProfile;
+    const provider = profile.provider || 'gas';
+    const defaultProfile = DEFAULT_PROFILES_BY_PROVIDER[provider] as ConfigProfile;
 
     switch (key) {
       case 'provider':


### PR DESCRIPTION
- プロバイダ別デフォルト設定を導入し，プロファイル作成時に適用
- GASプロバイダで endpoint 未指定時にデフォルトが失われる不具合 (#44) を解消
- unset/reset 時もプロバイダ固有のデフォルトへ戻すよう統一

変更内容
- `DEFAULT_PROFILES_BY_PROVIDER` でプロバイダごとの既定値を定義
- プロファイル作成時にプロバイダ既定値をベースにユーザ入力で上書き
- `unset` / `reset` が現在のプロバイダ既定値に戻すよう修正
- `readConfig` の不要なマージロジックを削除し簡素化

動作確認
- `enja config add foo --provider gas` で `endpoint` 未指定でもデフォルトが設定されること
- `enja config add bar --provider openai --model gpt-4o-mini` が期待どおり保存されること
- `enja config unset foo endpoint` でプロバイダ既定の `endpoint` に戻ること
- 既存プロファイルの切り替え・表示がエラーなく動作すること

Fixes #44