### PR TITLE
fix(config): デフォルトプロファイルのリセット制限を削除

### DIFF
--- a/src/services/config/storage.ts
+++ b/src/services/config/storage.ts
@@ -312,10 +312,6 @@ export class ConfigStorage implements ConfigManager {
 
   /** プロファイル全体をリセット */
   async resetProfile(profileName: string): Promise<void> {
-    if (profileName === 'default') {
-      throw new Error(`'default' プロファイルはリセットのみ可能です`);
-    }
-
     const appConfig = await this.readAppConfig();
 
     if (!appConfig.profiles[profileName]) {


### PR DESCRIPTION
デフォルトプロファイルはリセット不可としていたが，仕様を見直し，resetProfile の `default` 除外チェックを削除した．これにより，`default` を含むすべてのプロファイルを規定値に戻せるようにした．