### PR TITLE
chore: 設定ファイル形式が不正な場合の console 警告を削除

### DIFF
--- a/src/services/config/storage.ts
+++ b/src/services/config/storage.ts
@@ -298,10 +298,8 @@ export class ConfigStorage implements ConfigManager {
       if (ConfigStorage.isAppConfig(parsed)) {
         return parsed;
       }
-      console.warn('設定ファイルの形式が不正です．規定値を使用します');
       return { ...defaultAppConfig };
     } catch {
-      console.warn('設定読み込みに失敗しました．規定値を使用します');
       return { ...defaultAppConfig };
     }
   }


### PR DESCRIPTION
設定ファイル形式が不正な場合に出力していた console 警告を削除し，ログのノイズを減らした．動作への影響なし