### PR TITLE
feat(config): プロファイルごとにエンドポイントを許可するためのフラグを追加

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -30,6 +30,9 @@ Subcommands:
     .option('--endpoint <url>', 'プロファイルのエンドポイントを設定')
     .option('--api-key <api-key>', 'プロファイルの API キーを設定')
     .option('--model <name>', 'プロファイルのモデルを設定')
+    .option('--allow-local-endpoint', 'プロファイルで localhost のエンドポイントを許可')
+    .option('--allow-private-endpoint', 'プロファイルでプライベート IP のエンドポイントを許可')
+    .option('--allow-http', 'プロファイルで HTTP のエンドポイントを許可')
     .option('--unset <key>', 'プロファイルの指定した設定をリセット')
     .option('--reset', 'プロファイル全体をリセット')
     .addHelpText(
@@ -39,7 +42,7 @@ Subcommands:
     gas, openai, gemini, lmstudio, ollama, custom
 
   --unset Keys:
-    provider, endpoint, api-key, model
+    provider, endpoint, api-key, model, allow-local-endpoint, allow-private-endpoint, allow-http
 
   注意: --provider, --endpoint, --api-key, --model オプションは
       プロファイル名または 'add' サブコマンドと一緒に使用してください
@@ -148,6 +151,9 @@ export async function config(profileOrSubcommand?: string, _options?: ConfigOpti
       if (options?.endpoint) profileConfig.endpoint = options.endpoint;
       if (options?.apiKey) profileConfig.apiKey = options.apiKey;
       if (options?.model) profileConfig.model = options.model;
+      if (options?.allowLocalEndpoint) profileConfig.allowLocalEndpoint = options.allowLocalEndpoint;
+      if (options?.allowPrivateEndpoint) profileConfig.allowPrivateEndpoint = options.allowPrivateEndpoint;
+      if (options?.allowHttp) profileConfig.allowHttp = options.allowHttp;
 
       await storage.addProfile(subcommandArg, profileConfig);
       console.log(`${kleur.green('✔')} プロファイル '${subcommandArg}' を作成しました`);
@@ -205,11 +211,26 @@ export async function config(profileOrSubcommand?: string, _options?: ConfigOpti
       console.log(`${kleur.blue('endpoint:')} ${config.endpoint || '(not set)'}`);
       console.log(`${kleur.blue('apiKey:')} ${config.apiKey ? maskApiKey(config.apiKey) : '(not set)'}`);
       console.log(`${kleur.blue('model:')} ${config.model || '(not set)'}`);
+      console.log('\nPermissions:');
+      const flag = (label: string, v?: boolean) => `${kleur.blue(label)} ${v ? kleur.green('enabled') : kleur.gray('disabled')}`;
+      console.log(flag('local endpoint:', config.allowLocalEndpoint));
+      console.log(flag('private endpoint:', config.allowPrivateEndpoint));
+      console.log(flag('http:', config.allowHttp));
       return;
     }
 
     // プロファイル + オプション: プロファイルの設定を変更 (プロファイル表示より先に判定)
-    if (profileOrSubcommand && !subcommandArg && (options?.provider || options?.endpoint || options?.apiKey || options?.model)) {
+    if (
+      profileOrSubcommand &&
+      !subcommandArg &&
+      (options?.provider ||
+        options?.endpoint ||
+        options?.apiKey ||
+        options?.model ||
+        options?.allowLocalEndpoint ||
+        options?.allowPrivateEndpoint ||
+        options?.allowHttp)
+    ) {
       let updated = false;
 
       if (options.provider) {
@@ -228,6 +249,18 @@ export async function config(profileOrSubcommand?: string, _options?: ConfigOpti
         await storage.setProfileConfig(profileOrSubcommand, 'model', options.model);
         updated = true;
       }
+      if (options.allowLocalEndpoint) {
+        await storage.setProfileConfig(profileOrSubcommand, 'allow-local-endpoint', 'true');
+        updated = true;
+      }
+      if (options.allowPrivateEndpoint) {
+        await storage.setProfileConfig(profileOrSubcommand, 'allow-private-endpoint', 'true');
+        updated = true;
+      }
+      if (options.allowHttp) {
+        await storage.setProfileConfig(profileOrSubcommand, 'allow-http', 'true');
+        updated = true;
+      }
 
       if (updated) {
         console.log(`${kleur.green('✔')} プロファイル '${profileOrSubcommand}' の設定を更新しました`);
@@ -244,7 +277,10 @@ export async function config(profileOrSubcommand?: string, _options?: ConfigOpti
       !options?.provider &&
       !options?.endpoint &&
       !options?.apiKey &&
-      !options?.model
+      !options?.model &&
+      !options?.allowLocalEndpoint &&
+      !options?.allowPrivateEndpoint &&
+      !options?.allowHttp
     ) {
       const config = await storage.getProfile(profileOrSubcommand);
       console.log(`${kleur.bold('Profile:')} ${profileOrSubcommand}`);
@@ -252,6 +288,11 @@ export async function config(profileOrSubcommand?: string, _options?: ConfigOpti
       console.log(`${kleur.blue('endpoint:')} ${config.endpoint || '(not set)'}`);
       console.log(`${kleur.blue('apiKey:')} ${config.apiKey ? maskApiKey(config.apiKey) : '(not set)'}`);
       console.log(`${kleur.blue('model:')} ${config.model || '(not set)'}`);
+      console.log('\nPermissions:');
+      const flag = (label: string, v?: boolean) => `${kleur.blue(label)} ${v ? kleur.green('enabled') : kleur.gray('disabled')}`;
+      console.log(flag('local endpoint:', config.allowLocalEndpoint));
+      console.log(flag('private endpoint:', config.allowPrivateEndpoint));
+      console.log(flag('http:', config.allowHttp));
       return;
     }
 

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -13,4 +13,7 @@ export const RESERVED_WORDS: string[] = [
   'api-key',
   'model',
   'default',
+  'allow-local-endpoint',
+  'allow-private-endpoint',
+  'allow-http',
 ];

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -27,10 +27,17 @@ export async function getConfig(options?: TranslateOptions): Promise<ConfigProfi
 
   const model: string | undefined = options?.model || fileConfig.model;
 
+  const allowLocalEndpoint: boolean = options?.allowLocalEndpoint ?? fileConfig.allowLocalEndpoint ?? false;
+  const allowPrivateEndpoint: boolean = options?.allowPrivateEndpoint ?? fileConfig.allowPrivateEndpoint ?? false;
+  const allowHttp: boolean = options?.allowHttp ?? fileConfig.allowHttp ?? false;
+
   return {
     endpoint,
     provider,
     apiKey,
     model,
+    allowLocalEndpoint,
+    allowPrivateEndpoint,
+    allowHttp,
   };
 }

--- a/src/services/config/storage.ts
+++ b/src/services/config/storage.ts
@@ -1,5 +1,5 @@
 import { promises as fs } from 'node:fs';
-import type { AppConfig, ConfigProfile, TranslatorProvider } from '../../types/index.js';
+import type { AppConfig, ConfigKey, ConfigProfile, TranslatorProvider } from '../../types/index.js';
 import { getConfigDir, getConfigFilePath } from '../../utils/paths.js';
 import { CustomTranslator } from '../translator/custom.js';
 import { GASTranslator } from '../translator/gas.js';
@@ -187,7 +187,7 @@ export class ConfigStorage implements ConfigManager {
   }
 
   /** プロファイルの設定を変更 */
-  async setProfileConfig(profileName: string, key: string, value: string): Promise<void> {
+  async setProfileConfig(profileName: string, key: ConfigKey, value: string): Promise<void> {
     const appConfig = await this.readAppConfig();
 
     // プロファイルが存在しない場合はエラー
@@ -197,10 +197,39 @@ export class ConfigStorage implements ConfigManager {
 
     const profile = appConfig.profiles[profileName];
 
+    const allowedValues: { [key: string]: boolean } = {
+      true: true,
+      false: false,
+    };
+
     switch (key) {
       case 'endpoint':
         profile.endpoint = value;
         break;
+      case 'allow-local-endpoint': {
+        const v = String(value).toLowerCase();
+        if (!Object.hasOwn(allowedValues, v)) {
+          throw new Error(`無効な値 (${value}): allow-local-endpoint は 'true' または 'false' を指定してください`);
+        }
+        profile.allowLocalEndpoint = allowedValues[v];
+        break;
+      }
+      case 'allow-private-endpoint': {
+        const v = String(value).toLowerCase();
+        if (!Object.hasOwn(allowedValues, v)) {
+          throw new Error(`無効な値 (${value}): allow-private-endpoint は 'true' または 'false' を指定してください`);
+        }
+        profile.allowPrivateEndpoint = allowedValues[v];
+        break;
+      }
+      case 'allow-http': {
+        const v = String(value).toLowerCase();
+        if (!Object.hasOwn(allowedValues, v)) {
+          throw new Error(`無効な値 (${value}): allow-http は 'true' または 'false' を指定してください`);
+        }
+        profile.allowHttp = allowedValues[v];
+        break;
+      }
       case 'api-key':
         profile.apiKey = value;
         break;
@@ -222,7 +251,7 @@ export class ConfigStorage implements ConfigManager {
   }
 
   /** プロファイルの設定をリセット */
-  async unsetProfileConfig(profileName: string, key: string): Promise<void> {
+  async unsetProfileConfig(profileName: string, key: ConfigKey): Promise<void> {
     const appConfig = await this.readAppConfig();
 
     if (!appConfig.profiles[profileName]) {
@@ -236,6 +265,15 @@ export class ConfigStorage implements ConfigManager {
     switch (key) {
       case 'provider':
         profile.provider = defaultProfile.provider;
+        break;
+      case 'allow-local-endpoint':
+        profile.allowLocalEndpoint = defaultProfile.allowLocalEndpoint;
+        break;
+      case 'allow-private-endpoint':
+        profile.allowPrivateEndpoint = defaultProfile.allowPrivateEndpoint;
+        break;
+      case 'allow-http':
+        profile.allowHttp = defaultProfile.allowHttp;
         break;
       case 'endpoint':
         profile.endpoint = defaultProfile.endpoint;

--- a/src/services/translator/custom.ts
+++ b/src/services/translator/custom.ts
@@ -5,6 +5,9 @@ export class CustomTranslator implements Translator {
   static getDefaultProfile(): ConfigProfile {
     return {
       provider: 'custom',
+      allowLocalEndpoint: false,
+      allowPrivateEndpoint: false,
+      allowHttp: false,
     };
   }
 

--- a/src/services/translator/factory.ts
+++ b/src/services/translator/factory.ts
@@ -50,9 +50,9 @@ export async function createTranslator(options?: TranslateOptions): Promise<Tran
     activeProfile = await storage.getActiveProfileName();
   }
 
-  const allowLocalEndpoint = options?.allowLocalEndpoint ?? false;
-  const allowPrivateEndpoint = options?.allowPrivateEndpoint ?? false;
-  const allowHttp = options?.allowHttp ?? false;
+  const allowLocalEndpoint = options?.allowLocalEndpoint ?? config.allowLocalEndpoint ?? false;
+  const allowPrivateEndpoint = options?.allowPrivateEndpoint ?? config.allowPrivateEndpoint ?? false;
+  const allowHttp = options?.allowHttp ?? config.allowHttp ?? false;
   const validateEndpointOptions: ValidateEndpointOptions = {
     allowLocalEndpoint,
     allowPrivateEndpoint,

--- a/src/services/translator/gas.ts
+++ b/src/services/translator/gas.ts
@@ -17,6 +17,9 @@ export class GASTranslator implements Translator {
     return {
       provider: 'gas',
       endpoint: GASTranslator.DEFAULT_ENDPOINT,
+      allowLocalEndpoint: false,
+      allowPrivateEndpoint: false,
+      allowHttp: false,
     };
   }
 

--- a/src/services/translator/gemini.ts
+++ b/src/services/translator/gemini.ts
@@ -10,6 +10,9 @@ export class GeminiTranslator implements Translator {
     return {
       provider: 'gemini',
       model: GeminiTranslator.DEFAULT_MODEL,
+      allowLocalEndpoint: false,
+      allowPrivateEndpoint: false,
+      allowHttp: false,
     };
   }
 

--- a/src/services/translator/lmstudio.ts
+++ b/src/services/translator/lmstudio.ts
@@ -30,6 +30,9 @@ export class LMStudioTranslator implements Translator {
     return {
       provider: 'lmstudio',
       endpoint: LMStudioTranslator.DEFAULT_ENDPOINT,
+      allowLocalEndpoint: false,
+      allowPrivateEndpoint: false,
+      allowHttp: false,
     };
   }
 

--- a/src/services/translator/ollama.ts
+++ b/src/services/translator/ollama.ts
@@ -20,6 +20,9 @@ export class OllamaTranslator implements Translator {
       provider: OllamaTranslator.PROVIDER_NAME,
       endpoint: OllamaTranslator.DEFAULT_ENDPOINT,
       model: OllamaTranslator.DEFAULT_MODEL,
+      allowLocalEndpoint: false,
+      allowPrivateEndpoint: false,
+      allowHttp: false,
     };
   }
 

--- a/src/services/translator/openai.ts
+++ b/src/services/translator/openai.ts
@@ -9,6 +9,9 @@ export class OpenAITranslator implements Translator {
     return {
       provider: 'openai',
       model: OpenAITranslator.DEFAULT_MODEL,
+      allowLocalEndpoint: false,
+      allowPrivateEndpoint: false,
+      allowHttp: false,
     };
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -48,6 +48,9 @@ export interface ConfigProfile {
   endpoint?: string;
   apiKey?: string;
   model?: string;
+  allowLocalEndpoint: boolean;
+  allowPrivateEndpoint: boolean;
+  allowHttp: boolean;
 }
 
 export interface AppConfig {
@@ -65,8 +68,11 @@ export interface ConfigOptions {
   endpoint?: string;
   apiKey?: string;
   model?: string;
+  allowLocalEndpoint?: boolean;
+  allowPrivateEndpoint?: boolean;
+  allowHttp?: boolean;
 }
 
-export type ConfigKey = 'endpoint' | 'api-key' | 'provider' | 'model';
+export type ConfigKey = 'endpoint' | 'api-key' | 'provider' | 'model' | 'allow-local-endpoint' | 'allow-private-endpoint' | 'allow-http';
 
 export type TranslatorProvider = 'gas' | 'openai' | 'gemini' | 'lmstudio' | 'ollama' | 'custom';


### PR DESCRIPTION
設定プロファイルごとにローカル／プライベート／HTTP エンドポイントの使用を制御する3つのフラグを追加した．あわせて，CLI オプション対応，設定の永続化，`enja config` の表示対応，および各トランスレータ初期化への伝搬を実装した．これにより，従来はコマンド実行時に毎回明示的にフラグを指定する必要があった挙動を，プロファイル単位で事前に設定できるようになった．