### PR TITLE
fix(ci): ビルド必須シークレット未設定時の存在確認ステップを追加

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,11 +34,30 @@ jobs:
             exit 1
           fi
 
+      - name: Check mandatory environment variables
+        run: |
+          if [ -z "${{ secrets.GAS_DEFAULT_ENDPOINT }}" ]; then
+            echo "GAS_DEFAULT_ENDPOINT is not set"
+            exit 1
+          fi
+          if [ -z "${{ secrets.OPENAI_DEFAULT_MODEL }}" ]; then
+            echo "OPENAI_DEFAULT_MODEL is not set"
+            exit 1
+          fi
+          if [ -z "${{ secrets.GEMINI_DEFAULT_MODEL }}" ]; then
+            echo "GEMINI_DEFAULT_MODEL is not set"
+            exit 1
+          fi
+
       - name: Install dependencies
         run: npm ci
 
       - name: Build
         run: npm run build
+        env:
+          GAS_DEFAULT_ENDPOINT: ${{ secrets.GAS_DEFAULT_ENDPOINT }}
+          OPENAI_DEFAULT_MODEL: ${{ secrets.OPENAI_DEFAULT_MODEL }}
+          GEMINI_DEFAULT_MODEL: ${{ secrets.GEMINI_DEFAULT_MODEL }}
 
       - name: Publish to npm (OIDC)
         run: |


### PR DESCRIPTION
CIワークフローにおいて，ビルドに必要な環境変数（シークレット）が未設定の場合でもプロセスが空値で進行し，「ビルド成功」と誤認される状態を修正した．

変更点:

1.  `publish.yml` に環境変数定義セクション（`env`）を追加した
2.  ワークフロー実行時に，各必須シークレットの存在チェックを行う処理を導入し，未設定の場合はプロセスを停止させるロジックを組み込んだ

PRマージ後の対応:

PRマージ後に以下の手順が必須となる
1.  GitHub Actions の Settings > Secrets and variables > Actions にて，全必須シークレットに対して適切な値を登録する
2.  設定完了後，リリースワークフローを実行し，正常に動作することを確認する