### PR TITLE
refactor(translator): factory と設定解決を整理

### DIFF
--- a/src/commands/translate.ts
+++ b/src/commands/translate.ts
@@ -88,8 +88,6 @@ async function processTranslation(text: string, options: TranslateOptions, input
     }
   }
 
-  // 翻訳サービスの初期化
-  const { translator, config, activeProfile } = await createTranslator(options);
   const historyStorage = new HistoryStorage();
 
   // 翻訳処理
@@ -118,10 +116,11 @@ async function processTranslation(text: string, options: TranslateOptions, input
     return;
   }
 
+  // キャッシュにない場合のみ翻訳サービスを初期化
+  const { translator, profileName, provider } = await createTranslator(options);
   const dir = `(${sourceLang} → ${targetLang})`;
-  const model = translator.getModel() || config.model;
-  const profileName = activeProfile || 'unknown';
-  const profileInfo = `[${profileName} | ${config.provider}${model ? ` | ${model}` : ''}]`;
+  const model = translator.getModel();
+  const profileInfo = `[${profileName} | ${provider}${model ? ` | ${model}` : ''}]`;
 
   const spinner = ora(`翻訳中... ${dir} ${profileInfo}`).start();
   try {
@@ -137,8 +136,8 @@ async function processTranslation(text: string, options: TranslateOptions, input
       textLength: processedText.length,
       sourceHash: textHash,
       profile: profileName,
-      provider: config.provider,
-      model: model,
+      provider,
+      model: model ?? undefined,
       options: {
         stripHtml: options.stripHtml,
         file: options.file,

--- a/src/config/index.spec.ts
+++ b/src/config/index.spec.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ConfigProfile } from '../types/index.js';
+
+const { getResolvedProfile } = vi.hoisted(() => ({
+  getResolvedProfile: vi.fn(),
+}));
+
+vi.mock('../services/config/storage.js', () => ({
+  ConfigStorage: class {
+    getResolvedProfile = getResolvedProfile;
+  },
+}));
+
+import { resolveConfig } from './index.js';
+
+const profile: ConfigProfile = {
+  provider: 'gas',
+  endpoint: 'https://script.google.com/macros/s/example/exec',
+  apiKey: 'profile-key',
+  model: 'profile-model',
+  allowLocalEndpoint: false,
+  allowPrivateEndpoint: false,
+  allowHttp: false,
+};
+
+describe('resolveConfig', () => {
+  beforeEach(() => {
+    getResolvedProfile.mockReset();
+    getResolvedProfile.mockResolvedValue({ profileName: 'work', config: profile });
+  });
+
+  it('resolves the active profile and its config together', async () => {
+    const result = await resolveConfig();
+
+    expect(getResolvedProfile).toHaveBeenCalledOnce();
+    expect(getResolvedProfile).toHaveBeenCalledWith(undefined);
+    expect(result).toEqual({ profileName: 'work', config: profile });
+  });
+
+  it('passes an explicitly selected profile to storage', async () => {
+    await resolveConfig({ profile: 'personal' });
+
+    expect(getResolvedProfile).toHaveBeenCalledOnce();
+    expect(getResolvedProfile).toHaveBeenCalledWith('personal');
+  });
+
+  it('applies command options over the selected profile', async () => {
+    const result = await resolveConfig({
+      provider: 'ollama',
+      endpoint: 'http://localhost:11434',
+      apiKey: 'option-key',
+      model: 'option-model',
+      allowLocalEndpoint: true,
+      allowHttp: true,
+    });
+
+    expect(result).toEqual({
+      profileName: 'work',
+      config: {
+        provider: 'ollama',
+        endpoint: 'http://localhost:11434',
+        apiKey: 'option-key',
+        model: 'option-model',
+        allowLocalEndpoint: true,
+        allowPrivateEndpoint: false,
+        allowHttp: true,
+      },
+    });
+  });
+});

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,43 +1,25 @@
 import { ConfigStorage } from '../services/config/storage.js';
-import type { ConfigProfile, TranslateOptions, TranslatorProvider } from '../types/index.js';
+import type { ConfigProfile, TranslateOptions } from '../types/index.js';
 
-export async function getConfig(options?: TranslateOptions): Promise<ConfigProfile> {
+export interface ResolvedConfig {
+  profileName: string;
+  config: ConfigProfile;
+}
+
+export async function resolveConfig(options?: TranslateOptions): Promise<ResolvedConfig> {
   const storage = new ConfigStorage();
-
-  // プロファイル指定がある場合はそのプロファイルを取得
-  let fileConfig: ConfigProfile;
-  if (options?.profile) {
-    try {
-      fileConfig = await storage.getProfile(options.profile);
-    } catch {
-      const profiles = await storage.listProfiles();
-      throw new Error(`プロファイル '${options.profile}' が見つかりません\n利用可能なプロファイル: ${profiles.join(', ')}`);
-    }
-  } else {
-    // アクティブプロファイルを取得
-    fileConfig = await storage.get();
-  }
+  const { profileName, config: fileConfig } = await storage.getResolvedProfile(options?.profile);
 
   // 優先順位: コマンドラインオプション > プロファイル > デフォルト値
-  const provider: TranslatorProvider = options?.provider || fileConfig.provider || 'gas';
-
-  const endpoint: string | undefined = options?.endpoint || fileConfig.endpoint;
-
-  const apiKey: string | undefined = options?.apiKey || fileConfig.apiKey;
-
-  const model: string | undefined = options?.model || fileConfig.model;
-
-  const allowLocalEndpoint: boolean = options?.allowLocalEndpoint ?? fileConfig.allowLocalEndpoint ?? false;
-  const allowPrivateEndpoint: boolean = options?.allowPrivateEndpoint ?? fileConfig.allowPrivateEndpoint ?? false;
-  const allowHttp: boolean = options?.allowHttp ?? fileConfig.allowHttp ?? false;
-
-  return {
-    endpoint,
-    provider,
-    apiKey,
-    model,
-    allowLocalEndpoint,
-    allowPrivateEndpoint,
-    allowHttp,
+  const config: ConfigProfile = {
+    provider: options?.provider || fileConfig.provider || 'gas',
+    endpoint: options?.endpoint || fileConfig.endpoint,
+    apiKey: options?.apiKey || fileConfig.apiKey,
+    model: options?.model || fileConfig.model,
+    allowLocalEndpoint: options?.allowLocalEndpoint ?? fileConfig.allowLocalEndpoint ?? false,
+    allowPrivateEndpoint: options?.allowPrivateEndpoint ?? fileConfig.allowPrivateEndpoint ?? false,
+    allowHttp: options?.allowHttp ?? fileConfig.allowHttp ?? false,
   };
+
+  return { profileName, config };
 }

--- a/src/services/config/index.ts
+++ b/src/services/config/index.ts
@@ -1,7 +1,13 @@
 import type { ConfigProfile } from '../../types/index.js';
 
+export interface ResolvedProfile {
+  profileName: string;
+  config: ConfigProfile;
+}
+
 export interface ConfigManager {
   get(): Promise<ConfigProfile>;
+  getResolvedProfile(name?: string): Promise<ResolvedProfile>;
   getActiveProfileName(): Promise<string>;
   getProfile(name: string): Promise<ConfigProfile>;
   listProfiles(): Promise<string[]>;

--- a/src/services/config/storage.spec.ts
+++ b/src/services/config/storage.spec.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { AppConfig, ConfigProfile } from '../../types/index.js';
+import { ConfigStorage } from './storage.js';
+
+const defaultProfile: ConfigProfile = {
+  provider: 'gas',
+  endpoint: 'https://script.google.com/macros/s/default/exec',
+  allowLocalEndpoint: false,
+  allowPrivateEndpoint: false,
+  allowHttp: false,
+};
+
+const workProfile: ConfigProfile = {
+  provider: 'ollama',
+  endpoint: 'http://localhost:11434',
+  model: 'test-model',
+  allowLocalEndpoint: true,
+  allowPrivateEndpoint: false,
+  allowHttp: false,
+};
+
+function appConfig(activeProfile: string): AppConfig {
+  return {
+    version: '1.1',
+    activeProfile,
+    profiles: {
+      default: defaultProfile,
+      work: workProfile,
+    },
+  };
+}
+
+function mockAppConfig(storage: ConfigStorage, config: AppConfig) {
+  return vi.spyOn(storage as unknown as { readAppConfig(): Promise<AppConfig> }, 'readAppConfig').mockResolvedValue(config);
+}
+
+describe('ConfigStorage.getResolvedProfile', () => {
+  it('returns the active profile name and config from one read', async () => {
+    const storage = new ConfigStorage();
+    const readAppConfig = mockAppConfig(storage, appConfig('work'));
+
+    await expect(storage.getResolvedProfile()).resolves.toEqual({
+      profileName: 'work',
+      config: workProfile,
+    });
+    expect(readAppConfig).toHaveBeenCalledOnce();
+  });
+
+  it('returns an explicitly selected profile', async () => {
+    const storage = new ConfigStorage();
+    const readAppConfig = mockAppConfig(storage, appConfig('work'));
+
+    await expect(storage.getResolvedProfile('default')).resolves.toEqual({
+      profileName: 'default',
+      config: defaultProfile,
+    });
+    expect(readAppConfig).toHaveBeenCalledOnce();
+  });
+
+  it('falls back consistently when the active profile does not exist', async () => {
+    const storage = new ConfigStorage();
+    mockAppConfig(storage, appConfig('missing'));
+
+    await expect(storage.getResolvedProfile()).resolves.toEqual({
+      profileName: 'default',
+      config: defaultProfile,
+    });
+  });
+
+  it('reports available profiles when an explicitly selected profile does not exist', async () => {
+    const storage = new ConfigStorage();
+    mockAppConfig(storage, appConfig('work'));
+
+    await expect(storage.getResolvedProfile('missing')).rejects.toThrow(
+      "プロファイル 'missing' が見つかりません\n利用可能なプロファイル: default, work",
+    );
+  });
+});

--- a/src/services/config/storage.ts
+++ b/src/services/config/storage.ts
@@ -8,7 +8,7 @@ import { LMStudioTranslator } from '../translator/lmstudio.js';
 import { OllamaTranslator } from '../translator/ollama.js';
 import { OpenAITranslator } from '../translator/openai.js';
 import { validateProfileName } from '../validate/profile.js';
-import type { ConfigManager } from './index.js';
+import type { ConfigManager, ResolvedProfile } from './index.js';
 
 const DEFAULT_PROVIDER: TranslatorProvider = 'gas';
 
@@ -22,13 +22,15 @@ const defaultProfileFactories: Record<TranslatorProvider, () => ConfigProfile> =
   custom: CustomTranslator.getDefaultProfile,
 };
 
-const defaultAppConfig: AppConfig = {
-  version: '1.1',
-  activeProfile: 'default',
-  profiles: {
-    default: defaultProfileFactories[DEFAULT_PROVIDER](),
-  },
-};
+function createDefaultAppConfig(): AppConfig {
+  return {
+    version: '1.1',
+    activeProfile: 'default',
+    profiles: {
+      default: defaultProfileFactories[DEFAULT_PROVIDER](),
+    },
+  };
+}
 
 /** 設定の永続化を管理するクラス */
 export class ConfigStorage implements ConfigManager {
@@ -40,7 +42,29 @@ export class ConfigStorage implements ConfigManager {
 
   /** 設定を取得 */
   async get(): Promise<ConfigProfile> {
-    return await this.readConfig();
+    const { config } = await this.getResolvedProfile();
+    return config;
+  }
+
+  /** 指定された、またはアクティブなプロファイルを名前と設定の組で取得 */
+  async getResolvedProfile(name?: string): Promise<ResolvedProfile> {
+    const appConfig = await this.readAppConfig();
+    const profileName = name ?? appConfig.activeProfile;
+    const config = appConfig.profiles[profileName];
+
+    if (config) {
+      return { profileName, config };
+    }
+
+    if (name) {
+      const availableProfiles = Object.keys(appConfig.profiles).join(', ');
+      throw new Error(`プロファイル '${name}' が見つかりません\n利用可能なプロファイル: ${availableProfiles}`);
+    }
+
+    return {
+      profileName: 'default',
+      config: appConfig.profiles.default ?? this.getDefaultProfile(),
+    };
   }
 
   // プロファイル管理メソッド
@@ -336,9 +360,9 @@ export class ConfigStorage implements ConfigManager {
       if (ConfigStorage.isAppConfig(parsed)) {
         return parsed;
       }
-      return { ...defaultAppConfig };
+      return createDefaultAppConfig();
     } catch {
-      return { ...defaultAppConfig };
+      return createDefaultAppConfig();
     }
   }
 
@@ -352,11 +376,5 @@ export class ConfigStorage implements ConfigManager {
     } catch {
       throw new Error(`設定ファイルの書き込みに失敗しました`);
     }
-  }
-
-  private async readConfig(): Promise<ConfigProfile> {
-    const appConfig = await this.readAppConfig();
-    const activeProfile = appConfig.profiles[appConfig.activeProfile];
-    return activeProfile || this.getDefaultProfile();
   }
 }

--- a/src/services/translator/custom.ts
+++ b/src/services/translator/custom.ts
@@ -1,4 +1,6 @@
 import type { ConfigProfile } from '../../types/index.js';
+import type { ValidateEndpointOptions } from '../validate/endpoint.js';
+import { validateEndpoint } from '../validate/endpoint.js';
 import type { TranslationResult, Translator } from './index.js';
 
 export class CustomTranslator implements Translator {
@@ -11,12 +13,16 @@ export class CustomTranslator implements Translator {
     };
   }
 
-  private apiUrl: string;
+  private endpoint: string;
   private apiKey?: string;
   private model?: string;
 
-  constructor(endpoint: string, apiKey?: string, model?: string) {
-    this.apiUrl = endpoint;
+  constructor(endpoint?: string, apiKey?: string, model?: string, validateEndpointOptions?: ValidateEndpointOptions) {
+    if (!endpoint) {
+      throw new Error('エンドポイント URL が必要です');
+    }
+    validateEndpoint(endpoint, validateEndpointOptions);
+    this.endpoint = endpoint;
     this.apiKey = apiKey;
     this.model = model;
   }
@@ -35,7 +41,7 @@ export class CustomTranslator implements Translator {
       headers.Authorization = `Bearer ${this.apiKey}`;
     }
 
-    const res = await fetch(this.apiUrl, {
+    const res = await fetch(this.endpoint, {
       method: 'POST',
       headers,
       body: JSON.stringify({

--- a/src/services/translator/factory.spec.ts
+++ b/src/services/translator/factory.spec.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { resolveConfig } = vi.hoisted(() => ({
+  resolveConfig: vi.fn(),
+}));
+
+vi.mock('../../config/index.js', () => ({
+  resolveConfig,
+}));
+
+import { createTranslator } from './factory.js';
+import { LMStudioTranslator } from './lmstudio.js';
+import { OllamaTranslator } from './ollama.js';
+
+describe('createTranslator', () => {
+  beforeEach(() => {
+    resolveConfig.mockReset();
+  });
+
+  it('returns only the translator and non-sensitive metadata', async () => {
+    resolveConfig.mockResolvedValue({
+      profileName: 'local',
+      config: {
+        provider: 'ollama',
+        endpoint: 'http://localhost:11434',
+        apiKey: 'secret',
+        model: 'test-model',
+        allowLocalEndpoint: true,
+        allowPrivateEndpoint: false,
+        allowHttp: false,
+      },
+    });
+
+    const result = await createTranslator();
+
+    expect(result.translator).toBeInstanceOf(OllamaTranslator);
+    expect(result).toMatchObject({ profileName: 'local', provider: 'ollama' });
+    expect(result).not.toHaveProperty('config');
+  });
+
+  it('passes endpoint policy to the translator constructor', async () => {
+    resolveConfig.mockResolvedValue({
+      profileName: 'unsafe',
+      config: {
+        provider: 'ollama',
+        endpoint: 'http://localhost:11434',
+        model: 'test-model',
+        allowLocalEndpoint: false,
+        allowPrivateEndpoint: false,
+        allowHttp: false,
+      },
+    });
+
+    await expect(createTranslator()).rejects.toThrow('エンドポイント URL は https:// で始まる必要があります');
+  });
+
+  it('uses the trusted built-in endpoint when no endpoint is configured', async () => {
+    resolveConfig.mockResolvedValue({
+      profileName: 'local',
+      config: {
+        provider: 'lmstudio',
+        model: 'test-model',
+        allowLocalEndpoint: false,
+        allowPrivateEndpoint: false,
+        allowHttp: false,
+      },
+    });
+
+    const result = await createTranslator();
+
+    expect(result.translator).toBeInstanceOf(LMStudioTranslator);
+    expect(result.provider).toBe('lmstudio');
+  });
+});

--- a/src/services/translator/factory.spec.ts
+++ b/src/services/translator/factory.spec.ts
@@ -54,6 +54,22 @@ describe('createTranslator', () => {
     await expect(createTranslator()).rejects.toThrow('エンドポイント URL は https:// で始まる必要があります');
   });
 
+  it('rejects GAS selected over a profile without an endpoint', async () => {
+    resolveConfig.mockResolvedValue({
+      profileName: 'openai',
+      config: {
+        provider: 'gas',
+        apiKey: 'openai-secret',
+        model: 'openai-model',
+        allowLocalEndpoint: false,
+        allowPrivateEndpoint: false,
+        allowHttp: false,
+      },
+    });
+
+    await expect(createTranslator()).rejects.toThrow('エンドポイント URL が必要です');
+  });
+
   it('uses the trusted built-in endpoint when no endpoint is configured', async () => {
     resolveConfig.mockResolvedValue({
       profileName: 'local',

--- a/src/services/translator/factory.ts
+++ b/src/services/translator/factory.ts
@@ -1,8 +1,6 @@
-import { getConfig } from '../../config/index.js';
-import type { ConfigProfile, TranslateOptions } from '../../types/index.js';
-import { ConfigStorage } from '../config/storage.js';
+import { resolveConfig } from '../../config/index.js';
+import type { TranslateOptions, TranslatorProvider } from '../../types/index.js';
 import type { ValidateEndpointOptions } from '../validate/endpoint.js';
-import { validateEndpoint } from '../validate/endpoint.js';
 import { CustomTranslator } from './custom.js';
 import { GASTranslator } from './gas.js';
 import { GeminiTranslator } from './gemini.js';
@@ -11,105 +9,45 @@ import { LMStudioTranslator } from './lmstudio.js';
 import { OllamaTranslator } from './ollama.js';
 import { OpenAITranslator } from './openai.js';
 
-interface TranslatorProvider {
+export interface CreatedTranslator {
   translator: Translator;
-  config: ConfigProfile;
-  activeProfile: string;
+  profileName: string;
+  provider: TranslatorProvider;
 }
 
-type ResolveEndpointArgs = {
-  defaultUrl: string;
-  configUrl?: string;
-  optionUrl?: string;
-  validateOpts: ValidateEndpointOptions;
-};
-
-function resolveEndpoint({ defaultUrl, configUrl, optionUrl, validateOpts }: ResolveEndpointArgs): string {
-  if (optionUrl) {
-    validateEndpoint(optionUrl, validateOpts);
-    return optionUrl;
-  }
-
-  if (configUrl) {
-    validateEndpoint(configUrl, validateOpts);
-    return configUrl;
-  }
-
-  validateEndpoint(defaultUrl, { allowLocalEndpoint: true, allowPrivateEndpoint: true, allowHttp: true });
-  return defaultUrl;
-}
-
-export async function createTranslator(options?: TranslateOptions): Promise<TranslatorProvider> {
-  const storage = new ConfigStorage();
-  const config: ConfigProfile = await getConfig(options);
-
-  let activeProfile: string;
-  if (options?.profile) {
-    activeProfile = options.profile;
-  } else {
-    activeProfile = await storage.getActiveProfileName();
-  }
-
-  const allowLocalEndpoint = options?.allowLocalEndpoint ?? config.allowLocalEndpoint ?? false;
-  const allowPrivateEndpoint = options?.allowPrivateEndpoint ?? config.allowPrivateEndpoint ?? false;
-  const allowHttp = options?.allowHttp ?? config.allowHttp ?? false;
+export async function createTranslator(options?: TranslateOptions): Promise<CreatedTranslator> {
+  const { config, profileName } = await resolveConfig(options);
+  const { provider, endpoint, apiKey, model, allowLocalEndpoint, allowPrivateEndpoint, allowHttp } = config;
   const validateEndpointOptions: ValidateEndpointOptions = {
     allowLocalEndpoint,
     allowPrivateEndpoint,
     allowHttp,
   };
 
-  const { provider, endpoint, apiKey, model } = config;
+  let translator: Translator;
 
   switch (provider) {
-    case 'custom': {
-      if (!endpoint) {
-        throw new Error('エンドポイント URL が必要です');
-      }
-      validateEndpoint(endpoint, validateEndpointOptions);
-      return { translator: new CustomTranslator(endpoint, apiKey, model), config, activeProfile };
-    }
-    case 'gas': {
-      if (!endpoint) {
-        throw new Error('エンドポイント URL が必要です');
-      }
-      validateEndpoint(endpoint, validateEndpointOptions);
-      return { translator: new GASTranslator(endpoint, apiKey), config, activeProfile };
-    }
-    case 'openai': {
-      if (!apiKey) {
-        throw new Error('OpenAI を使用するには API キーが必要です');
-      }
-      return { translator: new OpenAITranslator(apiKey, model), config, activeProfile };
-    }
-    case 'gemini': {
-      if (!apiKey) {
-        throw new Error('Gemini を使用するには API キーが必要です');
-      }
-      return { translator: new GeminiTranslator(apiKey, model), config, activeProfile };
-    }
-    case 'lmstudio': {
-      if (!model) {
-        throw new Error('LM Studio を使用するにはモデル名が必要です');
-      }
-      const url = resolveEndpoint({
-        defaultUrl: LMStudioTranslator.DEFAULT_ENDPOINT,
-        configUrl: endpoint,
-        optionUrl: options?.endpoint,
-        validateOpts: validateEndpointOptions,
-      });
-      return { translator: new LMStudioTranslator(url, model, apiKey), config, activeProfile };
-    }
-    case 'ollama': {
-      const url = resolveEndpoint({
-        defaultUrl: OllamaTranslator.DEFAULT_ENDPOINT,
-        configUrl: endpoint,
-        optionUrl: options?.endpoint,
-        validateOpts: validateEndpointOptions,
-      });
-      return { translator: new OllamaTranslator(url, model, apiKey), config, activeProfile };
-    }
+    case 'custom':
+      translator = new CustomTranslator(endpoint, apiKey, model, validateEndpointOptions);
+      break;
+    case 'gas':
+      translator = new GASTranslator(endpoint, apiKey, validateEndpointOptions);
+      break;
+    case 'openai':
+      translator = new OpenAITranslator(apiKey, model);
+      break;
+    case 'gemini':
+      translator = new GeminiTranslator(apiKey, model);
+      break;
+    case 'lmstudio':
+      translator = new LMStudioTranslator(endpoint, model, apiKey, validateEndpointOptions);
+      break;
+    case 'ollama':
+      translator = new OllamaTranslator(endpoint, model, apiKey, validateEndpointOptions);
+      break;
     default:
       throw new Error(`サポートされていないプロバイダー (${provider}) です`);
   }
+
+  return { translator, profileName, provider };
 }

--- a/src/services/translator/gas.ts
+++ b/src/services/translator/gas.ts
@@ -27,7 +27,10 @@ export class GASTranslator implements Translator {
   private apiUrl: string;
   private apiKey?: string;
 
-  constructor(endpoint: string = GASTranslator.DEFAULT_ENDPOINT, apiKey?: string, validateEndpointOptions?: ValidateEndpointOptions) {
+  constructor(endpoint?: string, apiKey?: string, validateEndpointOptions?: ValidateEndpointOptions) {
+    if (!endpoint) {
+      throw new Error('エンドポイント URL が必要です');
+    }
     if (!GASTranslator.ENDPOINT_URL_PATTERN.test(endpoint)) {
       throw new Error('無効な GAS エンドポイント URL です');
     }

--- a/src/services/translator/gas.ts
+++ b/src/services/translator/gas.ts
@@ -1,4 +1,5 @@
 import type { ConfigProfile } from '../../types/index.js';
+import { type ValidateEndpointOptions, validateEndpoint } from '../validate/endpoint.js';
 import type { TranslationResult, Translator } from './index.js';
 
 interface GASApiResponse {
@@ -26,10 +27,11 @@ export class GASTranslator implements Translator {
   private apiUrl: string;
   private apiKey?: string;
 
-  constructor(endpoint: string = GASTranslator.DEFAULT_ENDPOINT, apiKey?: string) {
+  constructor(endpoint: string = GASTranslator.DEFAULT_ENDPOINT, apiKey?: string, validateEndpointOptions?: ValidateEndpointOptions) {
     if (!GASTranslator.ENDPOINT_URL_PATTERN.test(endpoint)) {
       throw new Error('無効な GAS エンドポイント URL です');
     }
+    validateEndpoint(endpoint, validateEndpointOptions);
     this.apiUrl = endpoint;
     this.apiKey = apiKey;
   }

--- a/src/services/translator/gemini.ts
+++ b/src/services/translator/gemini.ts
@@ -19,7 +19,10 @@ export class GeminiTranslator implements Translator {
   private client: GoogleGenAI;
   private model: string;
 
-  constructor(apiKey: string, model: string = GeminiTranslator.DEFAULT_MODEL) {
+  constructor(apiKey?: string, model: string = GeminiTranslator.DEFAULT_MODEL) {
+    if (!apiKey) {
+      throw new Error('Gemini を使用するには API キーが必要です');
+    }
     this.client = new GoogleGenAI({ apiKey });
     this.model = model;
   }

--- a/src/services/translator/lmstudio.ts
+++ b/src/services/translator/lmstudio.ts
@@ -1,4 +1,5 @@
 import type { ConfigProfile } from '../../types/index.js';
+import { type ValidateEndpointOptions, validateEndpoint } from '../validate/endpoint.js';
 import type { TranslationResult, Translator } from './index.js';
 
 type LMStudioError = {
@@ -36,12 +37,18 @@ export class LMStudioTranslator implements Translator {
     };
   }
 
-  private baseUrl: string;
+  private endpoint: string;
   private model: string;
   private apiKey?: string;
 
-  constructor(endpoint: string = LMStudioTranslator.DEFAULT_ENDPOINT, model: string, apiKey?: string) {
-    this.baseUrl = endpoint;
+  constructor(endpoint?: string, model?: string, apiKey?: string, validateEndpointOptions?: ValidateEndpointOptions) {
+    if (!model) {
+      throw new Error('LM Studio を使用するにはモデル名が必要です');
+    }
+    if (endpoint) {
+      validateEndpoint(endpoint, validateEndpointOptions);
+    }
+    this.endpoint = endpoint || LMStudioTranslator.DEFAULT_ENDPOINT;
     this.model = model;
     this.apiKey = apiKey;
   }
@@ -53,7 +60,7 @@ export class LMStudioTranslator implements Translator {
   async translate(text: string, sourceLang: string, targetLang: string): Promise<TranslationResult> {
     const systemPrompt = `You are a professional translator. Translate the following text from ${sourceLang} to ${targetLang}. Only return the translated text without any additional explanation.`;
 
-    const url = this.resolveEndpoint(this.baseUrl);
+    const url = this.resolveEndpoint(this.endpoint);
 
     const headers: HeadersInit = {
       'Content-Type': 'application/json',

--- a/src/services/translator/ollama.ts
+++ b/src/services/translator/ollama.ts
@@ -1,4 +1,5 @@
 import type { ConfigProfile } from '../../types/index.js';
+import { type ValidateEndpointOptions, validateEndpoint } from '../validate/endpoint.js';
 import type { TranslationResult, Translator } from './index.js';
 
 type OllamaResponse = {
@@ -26,12 +27,15 @@ export class OllamaTranslator implements Translator {
     };
   }
 
-  private baseUrl: string;
+  private endpoint: string;
   private model: string;
   private apiKey?: string;
 
-  constructor(endpoint?: string, model?: string, apiKey?: string) {
-    this.baseUrl = endpoint || OllamaTranslator.DEFAULT_ENDPOINT;
+  constructor(endpoint?: string, model?: string, apiKey?: string, validateEndpointOptions?: ValidateEndpointOptions) {
+    if (endpoint) {
+      validateEndpoint(endpoint, validateEndpointOptions);
+    }
+    this.endpoint = endpoint || OllamaTranslator.DEFAULT_ENDPOINT;
     this.model = model || OllamaTranslator.DEFAULT_MODEL;
     this.apiKey = apiKey;
   }
@@ -43,7 +47,7 @@ export class OllamaTranslator implements Translator {
   async translate(text: string, sourceLang: string, targetLang: string): Promise<TranslationResult> {
     const systemPrompt = `You are a professional translator. Translate the following text from ${sourceLang} to ${targetLang}. Only return the translated text without any additional explanation or comments.`;
 
-    const url = this.baseUrl.endsWith('/api/generate') ? this.baseUrl : `${this.baseUrl}/api/generate`;
+    const url = this.endpoint.endsWith('/api/generate') ? this.endpoint : `${this.endpoint}/api/generate`;
 
     const headers: HeadersInit = {
       'Content-Type': 'application/json',

--- a/src/services/translator/openai.ts
+++ b/src/services/translator/openai.ts
@@ -18,7 +18,10 @@ export class OpenAITranslator implements Translator {
   private client: OpenAI;
   private model: string;
 
-  constructor(apiKey: string, model: string = OpenAITranslator.DEFAULT_MODEL) {
+  constructor(apiKey?: string, model: string = OpenAITranslator.DEFAULT_MODEL) {
+    if (!apiKey) {
+      throw new Error('OpenAI を使用するには API キーが必要です');
+    }
     this.client = new OpenAI({ apiKey });
     this.model = model;
   }


### PR DESCRIPTION
translator 周りの factory や profile 設定の解決処理を整理した

変更内容：

- profile 名と設定の二重読み込みを解消
- factory の重複処理と戻り値を簡素化
- endpoint 検証を各 translator へ移動
- キャッシュミス時のみ translator を生成
- factory / config 周辺のテストを追加
