### PR TITLE
feat(translator): 翻訳スタイル指定オプションを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ enja "こんにちは" -F
 
 # OpenAI API を一時的に使用して翻訳
 enja "Hello, world!" --provider openai --api-key YOUR_OPENAI_API_KEY
+
+# フォーマルなスタイルで翻訳（OpenAI, Gemini, LM Studio, Ollama）
+enja "Hello, world!" --provider openai --api-key YOUR_OPENAI_API_KEY --style formal
 ```
 
 ### 履歴と設定

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -20,6 +20,7 @@ enja [text] [options]
 - `-o, --output <path>` - ファイルに出力する (デフォルト: 標準出力)
 - `-s, --strip-html` - HTML タグを除去してから翻訳する
 - `-N, --no-cache` - キャッシュを使用せずに再翻訳する
+- `--style <style>` - 翻訳スタイルを指定 ※ OpenAI，Gemini，LM Studio，Ollamaのみ（`formal`, `casual`, `technical`, `academic`, `business`）
 - `-F, --flip` - 翻訳方向を逆にする (デフォルト: 英語 → 日本語)
 - `-p, --profile <name>` - 使用するプロファイルを指定
 - `--endpoint <url>` 一時的にカスタム翻訳エンドポイントを指定（現在のプロファイルに適用）
@@ -63,6 +64,9 @@ enja "Hello, world!" --endpoint https://api.example.com/translate --api-key YOUR
 
 # OpenAI API を使用して翻訳
 enja "Hello, world!" --provider openai --api-key YOUR_OPENAI_API_KEY --model gpt-4o
+
+# フォーマルなスタイルで翻訳
+enja "Hello, world!" --provider openai --api-key YOUR_OPENAI_API_KEY --style formal
 
 # Gemini API を使用して翻訳
 enja "Hello, world!" --provider gemini --api-key YOUR_GEMINI_API_KEY --model gemini-1.5-flash

--- a/src/commands/translate.ts
+++ b/src/commands/translate.ts
@@ -3,7 +3,8 @@ import type { Command } from 'commander';
 import kleur from 'kleur';
 import ora from 'ora';
 import { HistoryStorage } from '../services/history/storage.js';
-import { createTranslator } from '../services/translator/factory.js';
+import { type CreatedTranslator, createTranslator } from '../services/translator/factory.js';
+import { assertStyleSupported, assertTranslatorStyle } from '../services/translator/prompt.js';
 import type { TranslateOptions } from '../types/index.js';
 import { hashText } from '../utils/hash.js';
 
@@ -15,6 +16,7 @@ export function translateCommand(program: Command): void {
     .option('-o, --output <path>', 'ファイルに出力する (デフォルト: 標準出力)')
     .option('-s, --strip-html', 'HTMLタグを除去してから翻訳する')
     .option('-N, --no-cache', 'キャッシュを使用せずに再翻訳する')
+    .option('--style <style>', '翻訳のスタイルを指定（formal, casual, technical, academic, business）')
     .option('-F, --flip', '翻訳方向を逆にする (default: 英語→日本語)')
     .option('-p, --profile <name>', '使用するプロファイルを指定')
     .option('--endpoint <url>', '一時的にカスタム翻訳エンドポイントを指定（現在のプロファイルに適用）')
@@ -89,13 +91,29 @@ async function processTranslation(text: string, options: TranslateOptions, input
   }
 
   const historyStorage = new HistoryStorage();
+  assertTranslatorStyle(options.style);
+
+  let createdTranslator: CreatedTranslator | undefined;
+  if (options.style) {
+    createdTranslator = await createTranslator(options);
+    assertStyleSupported(createdTranslator.provider, options.style);
+  }
 
   // 翻訳処理
   const sourceLang = options.flip ? 'ja' : 'en';
   const targetLang = options.flip ? 'en' : 'ja';
 
   // キャッシュチェック
-  const textHash = hashText(processedText);
+  const cacheSource = options.style
+    ? JSON.stringify({
+        text: processedText,
+        style: options.style,
+        profile: createdTranslator?.profileName,
+        provider: createdTranslator?.provider,
+        model: createdTranslator?.translator.getModel(),
+      })
+    : processedText;
+  const textHash = hashText(cacheSource);
   const cachedEntry = await historyStorage.findByHash(textHash, sourceLang, targetLang);
 
   if (cachedEntry && options.cache !== false) {
@@ -117,14 +135,14 @@ async function processTranslation(text: string, options: TranslateOptions, input
   }
 
   // キャッシュにない場合のみ翻訳サービスを初期化
-  const { translator, profileName, provider } = await createTranslator(options);
+  const { translator, profileName, provider } = createdTranslator ?? (await createTranslator(options));
   const dir = `(${sourceLang} → ${targetLang})`;
   const model = translator.getModel();
   const profileInfo = `[${profileName} | ${provider}${model ? ` | ${model}` : ''}]`;
 
   const spinner = ora(`翻訳中... ${dir} ${profileInfo}`).start();
   try {
-    const result = await translator.translate(processedText, sourceLang, targetLang);
+    const result = await translator.translate(processedText, sourceLang, targetLang, options.style);
     const translated = result.text;
     spinner.succeed(`翻訳完了 ${dir} ${profileInfo}`);
     // 履歴に保存
@@ -140,6 +158,7 @@ async function processTranslation(text: string, options: TranslateOptions, input
       model: model ?? undefined,
       options: {
         stripHtml: options.stripHtml,
+        style: options.style,
         file: options.file,
         inputMethod,
       },

--- a/src/commands/translate.ts
+++ b/src/commands/translate.ts
@@ -2,8 +2,9 @@ import * as fs from 'node:fs';
 import type { Command } from 'commander';
 import kleur from 'kleur';
 import ora from 'ora';
+import { resolveConfig } from '../config/index.js';
 import { HistoryStorage } from '../services/history/storage.js';
-import { type CreatedTranslator, createTranslator } from '../services/translator/factory.js';
+import { createTranslator } from '../services/translator/factory.js';
 import { assertStyleSupported, assertTranslatorStyle } from '../services/translator/prompt.js';
 import type { TranslateOptions } from '../types/index.js';
 import { hashText } from '../utils/hash.js';
@@ -93,24 +94,22 @@ async function processTranslation(text: string, options: TranslateOptions, input
   const historyStorage = new HistoryStorage();
   assertTranslatorStyle(options.style);
 
-  let createdTranslator: CreatedTranslator | undefined;
-  if (options.style) {
-    createdTranslator = await createTranslator(options);
-    assertStyleSupported(createdTranslator.provider, options.style);
-  }
+  const styledConfig = options.style ? await resolveConfig(options) : undefined;
+  if (styledConfig) assertStyleSupported(styledConfig.config.provider, options.style);
 
   // 翻訳処理
   const sourceLang = options.flip ? 'ja' : 'en';
   const targetLang = options.flip ? 'en' : 'ja';
 
   // キャッシュチェック
-  const cacheSource = options.style
+  const cacheSource = styledConfig
     ? JSON.stringify({
         text: processedText,
         style: options.style,
-        profile: createdTranslator?.profileName,
-        provider: createdTranslator?.provider,
-        model: createdTranslator?.translator.getModel(),
+        profile: styledConfig.profileName,
+        provider: styledConfig.config.provider,
+        model: styledConfig.config.model,
+        endpoint: styledConfig.config.endpoint,
       })
     : processedText;
   const textHash = hashText(cacheSource);
@@ -135,7 +134,7 @@ async function processTranslation(text: string, options: TranslateOptions, input
   }
 
   // キャッシュにない場合のみ翻訳サービスを初期化
-  const { translator, profileName, provider } = createdTranslator ?? (await createTranslator(options));
+  const { translator, profileName, provider } = await createTranslator(options);
   const dir = `(${sourceLang} → ${targetLang})`;
   const model = translator.getModel();
   const profileInfo = `[${profileName} | ${provider}${model ? ` | ${model}` : ''}]`;

--- a/src/services/history/formatter.ts
+++ b/src/services/history/formatter.ts
@@ -53,6 +53,7 @@ function formatDetailed(entries: HistoryEntry[]): string {
       const opts = [
         entry.options.inputMethod && `input=${entry.options.inputMethod}`,
         entry.options.stripHtml && 'stripHtml=true',
+        entry.options.style && `style=${entry.options.style}`,
         entry.options.file && `file=${entry.options.file}`,
       ]
         .filter(Boolean)

--- a/src/services/translator/custom.ts
+++ b/src/services/translator/custom.ts
@@ -1,7 +1,8 @@
-import type { ConfigProfile } from '../../types/index.js';
+import type { ConfigProfile, TranslatorStyle } from '../../types/index.js';
 import type { ValidateEndpointOptions } from '../validate/endpoint.js';
 import { validateEndpoint } from '../validate/endpoint.js';
 import type { TranslationResult, Translator } from './index.js';
+import { assertStyleSupported } from './prompt.js';
 
 export class CustomTranslator implements Translator {
   static getDefaultProfile(): ConfigProfile {
@@ -31,7 +32,9 @@ export class CustomTranslator implements Translator {
     return this.model || null;
   }
 
-  async translate(text: string, sourceLang: string, targetLang: string): Promise<TranslationResult> {
+  async translate(text: string, sourceLang: string, targetLang: string, style?: TranslatorStyle): Promise<TranslationResult> {
+    assertStyleSupported('custom', style);
+
     const headers: HeadersInit = {
       'Content-Type': 'application/json',
       Accept: 'application/json',

--- a/src/services/translator/gas.ts
+++ b/src/services/translator/gas.ts
@@ -1,6 +1,7 @@
-import type { ConfigProfile } from '../../types/index.js';
+import type { ConfigProfile, TranslatorStyle } from '../../types/index.js';
 import { type ValidateEndpointOptions, validateEndpoint } from '../validate/endpoint.js';
 import type { TranslationResult, Translator } from './index.js';
+import { assertStyleSupported } from './prompt.js';
 
 interface GASApiResponse {
   code: number;
@@ -43,7 +44,9 @@ export class GASTranslator implements Translator {
     return null;
   }
 
-  async translate(text: string, sourceLang: string, targetLang: string): Promise<TranslationResult> {
+  async translate(text: string, sourceLang: string, targetLang: string, style?: TranslatorStyle): Promise<TranslationResult> {
+    assertStyleSupported('gas', style);
+
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
     };

--- a/src/services/translator/gemini.ts
+++ b/src/services/translator/gemini.ts
@@ -1,7 +1,8 @@
 import type { GenerateContentResponse } from '@google/genai';
 import { ApiError, GoogleGenAI } from '@google/genai';
-import type { ConfigProfile } from '../../types/index.js';
+import type { ConfigProfile, TranslatorStyle } from '../../types/index.js';
 import type { TranslationResult, Translator } from './index.js';
+import { buildSystemPrompt } from './prompt.js';
 
 export class GeminiTranslator implements Translator {
   static readonly DEFAULT_MODEL = process.env.GEMINI_DEFAULT_MODEL || 'gemini-2.5-flash-lite';
@@ -31,12 +32,9 @@ export class GeminiTranslator implements Translator {
     return this.model;
   }
 
-  async translate(text: string, sourceLang: string, targetLang: string): Promise<TranslationResult> {
+  async translate(text: string, sourceLang: string, targetLang: string, style?: TranslatorStyle): Promise<TranslationResult> {
     try {
-      const sourceLanguage = this.mapLanguageCode(sourceLang);
-      const targetLanguage = this.mapLanguageCode(targetLang);
-
-      const systemPrompt = `You are a professional translator. Translate the following text from ${sourceLanguage} to ${targetLanguage}. Only return the translated text without any additional explanation or comments.`;
+      const systemPrompt = buildSystemPrompt(sourceLang, targetLang, style);
 
       const response: GenerateContentResponse = await this.client.models.generateContent({
         model: this.model,
@@ -65,14 +63,5 @@ export class GeminiTranslator implements Translator {
       }
       throw error;
     }
-  }
-
-  private mapLanguageCode(code: string): string {
-    const languageMap: Record<string, string> = {
-      en: 'English',
-      ja: 'Japanese',
-    };
-
-    return languageMap[code.toLowerCase()] || code;
   }
 }

--- a/src/services/translator/index.ts
+++ b/src/services/translator/index.ts
@@ -1,3 +1,5 @@
+import type { TranslatorStyle } from '../../types/index.js';
+
 export interface TranslationResult {
   text: string;
   detectedSourceLang?: string;
@@ -5,5 +7,5 @@ export interface TranslationResult {
 
 export interface Translator {
   getModel(): string | null;
-  translate(text: string, sourceLang: string, targetLang: string): Promise<TranslationResult>;
+  translate(text: string, sourceLang: string, targetLang: string, style?: TranslatorStyle): Promise<TranslationResult>;
 }

--- a/src/services/translator/lmstudio.ts
+++ b/src/services/translator/lmstudio.ts
@@ -1,6 +1,7 @@
-import type { ConfigProfile } from '../../types/index.js';
+import type { ConfigProfile, TranslatorStyle } from '../../types/index.js';
 import { type ValidateEndpointOptions, validateEndpoint } from '../validate/endpoint.js';
 import type { TranslationResult, Translator } from './index.js';
+import { buildSystemPrompt } from './prompt.js';
 
 type LMStudioError = {
   message?: string;
@@ -57,8 +58,8 @@ export class LMStudioTranslator implements Translator {
     return this.model || null;
   }
 
-  async translate(text: string, sourceLang: string, targetLang: string): Promise<TranslationResult> {
-    const systemPrompt = `You are a professional translator. Translate the following text from ${sourceLang} to ${targetLang}. Only return the translated text without any additional explanation.`;
+  async translate(text: string, sourceLang: string, targetLang: string, style?: TranslatorStyle): Promise<TranslationResult> {
+    const systemPrompt = buildSystemPrompt(sourceLang, targetLang, style);
 
     const url = this.resolveEndpoint(this.endpoint);
 

--- a/src/services/translator/ollama.ts
+++ b/src/services/translator/ollama.ts
@@ -1,6 +1,7 @@
-import type { ConfigProfile } from '../../types/index.js';
+import type { ConfigProfile, TranslatorStyle } from '../../types/index.js';
 import { type ValidateEndpointOptions, validateEndpoint } from '../validate/endpoint.js';
 import type { TranslationResult, Translator } from './index.js';
+import { buildSystemPrompt } from './prompt.js';
 
 type OllamaResponse = {
   response: string;
@@ -44,8 +45,8 @@ export class OllamaTranslator implements Translator {
     return this.model || null;
   }
 
-  async translate(text: string, sourceLang: string, targetLang: string): Promise<TranslationResult> {
-    const systemPrompt = `You are a professional translator. Translate the following text from ${sourceLang} to ${targetLang}. Only return the translated text without any additional explanation or comments.`;
+  async translate(text: string, sourceLang: string, targetLang: string, style?: TranslatorStyle): Promise<TranslationResult> {
+    const systemPrompt = buildSystemPrompt(sourceLang, targetLang, style);
 
     const url = this.endpoint.endsWith('/api/generate') ? this.endpoint : `${this.endpoint}/api/generate`;
 

--- a/src/services/translator/openai.ts
+++ b/src/services/translator/openai.ts
@@ -1,6 +1,7 @@
 import OpenAI from 'openai';
-import type { ConfigProfile } from '../../types/index.js';
+import type { ConfigProfile, TranslatorStyle } from '../../types/index.js';
 import type { TranslationResult, Translator } from './index.js';
+import { buildSystemPrompt } from './prompt.js';
 
 export class OpenAITranslator implements Translator {
   public static readonly DEFAULT_MODEL = process.env.OPENAI_DEFAULT_MODEL || 'gpt-4o-mini';
@@ -30,12 +31,9 @@ export class OpenAITranslator implements Translator {
     return this.model;
   }
 
-  async translate(text: string, sourceLang: string, targetLang: string): Promise<TranslationResult> {
+  async translate(text: string, sourceLang: string, targetLang: string, style?: TranslatorStyle): Promise<TranslationResult> {
     try {
-      const sourceLanguage = this.mapLanguageCode(sourceLang);
-      const targetLanguage = this.mapLanguageCode(targetLang);
-
-      const systemPrompt = `You are a professional translator. Translate the following text from ${sourceLanguage} to ${targetLanguage}. Only return the translated text without any additional explanation or comments.`;
+      const systemPrompt = buildSystemPrompt(sourceLang, targetLang, style);
 
       const completion = await this.client.chat.completions.create({
         model: this.model,
@@ -70,14 +68,5 @@ export class OpenAITranslator implements Translator {
       }
       throw error;
     }
-  }
-
-  private mapLanguageCode(code: string): string {
-    const languageMap: Record<string, string> = {
-      en: 'English',
-      ja: 'Japanese',
-    };
-
-    return languageMap[code.toLowerCase()] || code;
   }
 }

--- a/src/services/translator/prompt.spec.ts
+++ b/src/services/translator/prompt.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import type { TranslatorStyle } from '../../types/index.js';
+import { assertStyleSupported, assertTranslatorStyle, buildSystemPrompt } from './prompt.js';
+
+const translatorStyles: readonly TranslatorStyle[] = ['formal', 'casual', 'technical', 'academic', 'business'];
+
+const expectedInstructions: Record<TranslatorStyle, string> = {
+  formal: 'formal, polite, and professional',
+  casual: 'natural, friendly, and conversational',
+  technical: 'technical accuracy',
+  academic: 'objective, precise, and academic',
+  business: 'professional business language',
+};
+
+describe('translator style', () => {
+  it.each(translatorStyles)('adds the %s instruction to the prompt', (style) => {
+    const prompt = buildSystemPrompt('en', 'ja', style);
+
+    expect(prompt).toContain('English');
+    expect(prompt).toContain('Japanese');
+    expect(prompt).toContain(expectedInstructions[style]);
+  });
+
+  it('omits style requirements when style is not specified', () => {
+    expect(buildSystemPrompt('en', 'ja')).not.toContain('Additional translation style requirements');
+  });
+
+  it('rejects an invalid runtime style', () => {
+    expect(() => assertTranslatorStyle('pirate')).toThrow('無効な翻訳スタイルです');
+  });
+
+  it.each(['gas', 'custom'] as const)('rejects style for the %s provider', (provider) => {
+    expect(() => assertStyleSupported(provider, 'formal')).toThrow('スタイル指定はサポートされていません');
+  });
+
+  it.each(['openai', 'gemini', 'lmstudio', 'ollama'] as const)('accepts style for the %s provider', (provider) => {
+    expect(() => assertStyleSupported(provider, 'formal')).not.toThrow();
+  });
+});

--- a/src/services/translator/prompt.ts
+++ b/src/services/translator/prompt.ts
@@ -1,0 +1,51 @@
+import type { TranslatorProvider, TranslatorStyle } from '../../types/index.js';
+
+const TRANSLATOR_STYLES: readonly TranslatorStyle[] = ['formal', 'casual', 'technical', 'academic', 'business'];
+
+const STYLE_INSTRUCTIONS: Record<TranslatorStyle, string> = {
+  formal: 'Use a formal, polite, and professional tone.',
+  casual: 'Use a natural, friendly, and conversational tone.',
+  technical: 'Prioritize technical accuracy and preserve domain-specific terminology.',
+  academic: 'Use an objective, precise, and academic writing style.',
+  business: 'Use concise, clear, and professional business language.',
+};
+
+const STYLE_SUPPORTED_PROVIDERS = new Set<TranslatorProvider>(['openai', 'gemini', 'lmstudio', 'ollama']);
+
+export function assertTranslatorStyle(style: unknown): asserts style is TranslatorStyle | undefined {
+  if (style === undefined) return;
+  if (typeof style !== 'string' || !(TRANSLATOR_STYLES as readonly string[]).includes(style)) {
+    throw new Error(`無効な翻訳スタイルです (${String(style)})\n利用可能なスタイル: ${TRANSLATOR_STYLES.join(', ')}`);
+  }
+}
+
+export function assertStyleSupported(provider: TranslatorProvider, style?: TranslatorStyle): void {
+  if (style && !STYLE_SUPPORTED_PROVIDERS.has(provider)) {
+    throw new Error(`${provider === 'gas' ? 'GAS' : 'Custom'} プロバイダーではスタイル指定はサポートされていません`);
+  }
+}
+
+export function buildSystemPrompt(sourceLang: string, targetLang: string, style?: TranslatorStyle): string {
+  assertTranslatorStyle(style);
+
+  const sourceLanguage = mapLanguageCode(sourceLang);
+  const targetLanguage = mapLanguageCode(targetLang);
+
+  return [
+    'You are a professional translator.',
+    `Translate the provided text from ${sourceLanguage} to ${targetLanguage}.`,
+    style ? `Additional translation style requirements:\n${STYLE_INSTRUCTIONS[style]}` : undefined,
+    'Return only the translated text without explanations or comments.',
+  ]
+    .filter(Boolean)
+    .join('\n\n');
+}
+
+function mapLanguageCode(code: string): string {
+  const languageMap: Record<string, string> = {
+    en: 'English',
+    ja: 'Japanese',
+  };
+
+  return languageMap[code.toLowerCase()] || code;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,6 +4,7 @@ export interface TranslateOptions {
   stripHtml?: boolean;
   cache?: boolean;
   flip?: boolean;
+  style?: TranslatorStyle;
   endpoint?: string;
   apiKey?: string;
   provider?: TranslatorProvider;
@@ -28,6 +29,7 @@ export interface HistoryEntry {
   model?: string;
   options?: {
     stripHtml?: boolean;
+    style?: TranslatorStyle;
     file?: string;
     inputMethod?: 'arg' | 'stdin' | 'file';
     command?: string;
@@ -76,3 +78,5 @@ export interface ConfigOptions {
 export type ConfigKey = 'endpoint' | 'api-key' | 'provider' | 'model' | 'allow-local-endpoint' | 'allow-private-endpoint' | 'allow-http';
 
 export type TranslatorProvider = 'gas' | 'openai' | 'gemini' | 'lmstudio' | 'ollama' | 'custom';
+
+export type TranslatorStyle = 'formal' | 'casual' | 'technical' | 'academic' | 'business';


### PR DESCRIPTION
OpenAI，Gemini，LM Studio，Ollama の翻訳プロバイダーに翻訳スタイル（formal, casual, technical, academic, business）を指定できる `--style` オプションを追加した．